### PR TITLE
fix(verify-ledger): accept inline-backtick chain hashes

### DIFF
--- a/qor/scripts/ledger_hash.py
+++ b/qor/scripts/ledger_hash.py
@@ -85,7 +85,13 @@ def _atomic_write_json(path: Path, data: dict) -> None:
 ENTRY_RE = re.compile(r"^### Entry #(\d+):", re.MULTILINE)
 CONTENT_HASH_RE = re.compile(r"\*\*Content Hash\*\*.*?`([0-9a-f]{64})`", re.DOTALL)
 PREV_HASH_RE = re.compile(r"\*\*Previous Hash\*\*.*?`([0-9a-f]{64})`", re.DOTALL)
-CHAIN_HASH_RE = re.compile(r"Chain Hash.*?= ([0-9a-f]{64})", re.DOTALL)
+# Chain Hash accepts either form: `= <hex>` (fenced/equation) or `` `<hex>` `` (inline backtick).
+# The inline-backtick form is symmetric with CONTENT_HASH_RE / PREV_HASH_RE; the equation form
+# preserves backward compatibility with legacy entries written before Phase 23.
+CHAIN_HASH_RE = re.compile(
+    r"Chain Hash.*?(?:=\s*([0-9a-f]{64})\b|`([0-9a-f]{64})`)",
+    re.DOTALL,
+)
 
 
 def verify(ledger_md: Path) -> int:
@@ -111,7 +117,8 @@ def verify(ledger_md: Path) -> int:
         if not (ch and ph and xh):
             skipped += 1
             continue
-        recorded = xh.group(1)
+        # CHAIN_HASH_RE has two alternation groups; exactly one is populated.
+        recorded = xh.group(1) or xh.group(2)
         new_expected = chain_hash(ch.group(1), ph.group(1))
         old_expected = legacy_chain_hash(ch.group(1), ph.group(1))
         if new_expected == recorded or old_expected == recorded:

--- a/tests/test_ledger_hash.py
+++ b/tests/test_ledger_hash.py
@@ -275,6 +275,74 @@ def test_verify_handles_missing_hash_markers_gracefully(tmp_path):
     assert rc == 0  # No errors; entries are skipped, not failed
 
 
+def test_verify_accepts_inline_backtick_chain_hash(tmp_path):
+    """Chain hashes written as `` `<hex>` `` verify identically to `= <hex>` form.
+
+    Ensures the canonical inline-backtick markup (symmetric with Content/Previous)
+    is accepted by the verifier. Regression test for downstream projects whose
+    ledgers adopt the inline form to satisfy all three hash-field regexes with
+    one consistent markup.
+    """
+    content_a = "a" * 64
+    prev_a = "0" * 64
+    chain_a = lh.chain_hash(content_a, prev_a)
+    content_b = "b" * 64
+    chain_b = lh.chain_hash(content_b, chain_a)
+
+    fake_ledger = tmp_path / "ledger.md"
+    fake_ledger.write_text(f"""### Entry #1: INLINE-BACKTICK CHAIN
+**Content Hash**: `{content_a}`
+**Previous Hash**: `{prev_a}`
+**Chain Hash**: `{chain_a}`
+
+### Entry #2: ALSO INLINE
+**Content Hash**: `{content_b}`
+**Previous Hash**: `{chain_a}`
+**Chain Hash**: `{chain_b}`
+""", encoding="utf-8")
+    rc = lh.verify(fake_ledger)
+    assert rc == 0
+
+
+def test_verify_accepts_mixed_chain_hash_forms(tmp_path):
+    """A ledger with one `= <hex>` entry and one `` `<hex>` `` entry verifies clean."""
+    content_a = "a" * 64
+    prev_a = "0" * 64
+    chain_a = lh.chain_hash(content_a, prev_a)
+    content_b = "b" * 64
+    chain_b = lh.chain_hash(content_b, chain_a)
+
+    fake_ledger = tmp_path / "ledger.md"
+    fake_ledger.write_text(f"""### Entry #1: EQUATION FORM
+**Content Hash**: `{content_a}`
+**Previous Hash**: `{prev_a}`
+Chain Hash = {chain_a}
+
+### Entry #2: INLINE FORM
+**Content Hash**: `{content_b}`
+**Previous Hash**: `{chain_a}`
+**Chain Hash**: `{chain_b}`
+""", encoding="utf-8")
+    rc = lh.verify(fake_ledger)
+    assert rc == 0
+
+
+def test_verify_detects_tampered_inline_backtick_chain(tmp_path):
+    """Inline-backtick chain with a wrong hash should still be detected as FAIL."""
+    content_a = "a" * 64
+    prev_a = "0" * 64
+    wrong_chain = "deadbeef" * 8  # 64 hex but wrong
+
+    fake_ledger = tmp_path / "ledger.md"
+    fake_ledger.write_text(f"""### Entry #1: TAMPERED INLINE
+**Content Hash**: `{content_a}`
+**Previous Hash**: `{prev_a}`
+**Chain Hash**: `{wrong_chain}`
+""", encoding="utf-8")
+    rc = lh.verify(fake_ledger)
+    assert rc == 1
+
+
 def test_verify_handles_malformed_numeric_id(tmp_path):
     """Verify() processes entry headers even if surrounding markup is unusual.
 


### PR DESCRIPTION
## Summary
- `CHAIN_HASH_RE` required `= <hex>`; `CONTENT_HASH_RE` / `PREV_HASH_RE` required `` `<hex>` ``. No single markup satisfied all three, so downstream ledgers had to use hybrid formats.
- Widens `CHAIN_HASH_RE` to accept either form without breaking legacy entries.
- Adds 3 regression tests covering inline-backtick, mixed-form, and tampered-inline cases. All 355 tests pass locally.

## Why

Discovered while adopting v0.14.0 in a downstream project (a sibling governance repository). Its ledger historically used three markup variants (inline backticks, fenced `= <hex>`, session-seal labels). Under the current regexes: 19 FAIL, 196 skipped, ~30 OK — not because of integrity problems but purely because no common markup could satisfy all three patterns. With this fix, the canonical form

```
**Content Hash**: `<hex>`
**Previous Hash**: `<hex>`
**Chain Hash**: `<hex>`
```

verifies cleanly — symmetric, idiomatic, no redundant `= <hex>` suffix needed.

## Change

`CHAIN_HASH_RE` now matches two alternation groups:

```python
CHAIN_HASH_RE = re.compile(
    r"Chain Hash.*?(?:=\s*([0-9a-f]{64})\b|`([0-9a-f]{64})`)",
    re.DOTALL,
)
```

`verify()` reads `xh.group(1) or xh.group(2)`. The existing `= <hex>` path (both inline and fenced) is preserved; the new inline-backtick path is additive.

## Test plan
- [x] `pytest tests/test_ledger_hash.py` — 21 passed (18 existing + 3 new)
- [x] `pytest` (full suite) — 355 passed, 0 failures
- [x] Downstream sanity: a sibling governance repository's migrated 245-entry ledger verifies clean aside from 12 pre-existing authoring-error entries (distinct integrity finding, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)