### PR TITLE
Phase 34 hotfix: CLI __version__ reads from package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ file is the user-facing narrative.
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-04-19
+
+### Fixed
+- **CLI `__version__` drift (SG-Phase34-A)**: `qor/cli.py` hardcoded `__version__ = "0.18.0"` and never got updated across six releases (v0.18.0 → v0.24.0). `qorlogic --version` printed `0.18.0` even on v0.24.0 installs. `__version__` now reads from `importlib.metadata.version("qor-logic")` at import time; fallback `"0+unknown"` for uninstalled source checkouts. Regression guard `tests/test_cli_version_from_metadata.py` asserts runtime lookup and forbids reintroduction of a SemVer-shaped string literal on the `__version__` line.
+
 ## [0.24.0] - 2026-04-19
 
 ### Fixed

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -4199,6 +4199,39 @@ Phase 32 Self-substantiation: Step 4.7 with strict=True will run against Phase 3
 *Merkle seal: 48039bb420...*
 
 
+### Entry #114: SESSION SEAL -- Phase 34 hotfix substantiated
+
+**Timestamp**: 2026-04-19
+**Phase**: SEAL (hotfix)
+**Author**: Judge
+**Verdict**: PASS (638 tests green on 2 consecutive runs; Phase 33 seal-tag timing fix exercised cleanly)
+
+**Target**: `docs/plan-qor-phase34-cli-version-hotfix.md`
+**Change Class**: `hotfix`
+**Version**: `0.24.0 -> 0.24.1`
+**Tag**: `v0.24.1` (will be created at Step 9.5.5 post-commit)
+
+**Content Hash**: `e96c520bc4a175759ad61f77855191f950a764e2f38bf8f90c754908d26fc22f`
+**Previous Hash**: `48039bb420c440b63de0291401e3611dbc9ef7ec21235cad5129a6ad6f327e3a`
+**Chain Hash**: `a840c3b5eb03e69096e52ce898bb9988c67311f0bd046feaea102bd0681e8d3a`
+
+**Scope**: single CLI hotfix. `qor/cli.py` `__version__` now reads from `importlib.metadata.version("qor-logic")` at import time; hardcoded string `"0.18.0"` (stale since v0.18.0 — six releases) removed. Regression guard `tests/test_cli_version_from_metadata.py` with 2 tests: runtime-lookup parity + Rule-4 structural lint forbidding SemVer string literals on the `__version__` line.
+
+**SG entry**: Entry #24 SG-Phase34-A (hardcoded version drift — third recurrence of the "state duplicated away from source of truth" pattern, after SG-Phase32-B README drift and SG-Phase33-A seal-tag timing).
+
+**Step 6.5 currency check**: hotfix class is exempt from the Phase 33 release-doc rule (change_class=hotfix); no release-doc warnings expected.
+
+**Hotfix justification**: `pip install qor-logic` on v0.24.0 yields `qorlogic --version` → `0.18.0`. User-visible incorrect behavior on the installed artifact. Small surface (one file + one test), unblocks users immediately.
+
+**Decision**: Phase 34 sealed. Phase 35 candidate: extend Rule-4 structural lint to ALL source files — grep for SemVer-shaped string literals outside pyproject.toml / CHANGELOG.md / META_LEDGER.md / SHADOW_GENOME.md. Catches any future hardcoded-version creep in one sweep.
+
+---
+
+*Chain integrity: VALID*
+*Session: SEALED* (rotation pending)
+*Merkle seal: a840c3b5eb...*
+
+
 
 
 

--- a/docs/SHADOW_GENOME.md
+++ b/docs/SHADOW_GENOME.md
@@ -767,4 +767,49 @@ SG-Phase33-A (seal_tag_timing: tagging before the seal commit targets the pre-se
 
 ---
 
+## Entry #24: hardcoded CLI __version__ drift across six releases
+
+**Timestamp**: 2026-04-19
+**Target**: `qor/cli.py` `__version__ = "0.18.0"`
+**Context**: surfaced during Phase 33 post-seal smoke test. `qorlogic --version` reported `0.18.0` after installing v0.24.0 from PyPI.
+
+### Pattern
+
+`qor/cli.py:13` held a hardcoded string `__version__ = "0.18.0"`. Between v0.18.0 and v0.24.0, the version bump happened six times in `pyproject.toml` (authored by `governance_helpers.bump_version` at `/qor-substantiate` Step 7.5) but the CLI constant was never touched because nothing mechanically linked the two. `pip show qor-logic` reported the correct version (reads pyproject metadata); `qorlogic --version` reported the stale string.
+
+### Why It Matters
+
+Third recurrence of the same root pattern:
+- SG-Phase32-B: README's `## What's new in v0.22.0` heading survived into v0.23.0.
+- SG-Phase33-A: annotated tag placed on pre-seal HEAD targeted stale `pyproject.toml`.
+- SG-Phase34-A (this): CLI `__version__` string literal drifted from pyproject for six releases.
+
+Common mechanism: **state duplicated away from its single source of truth drifts silently because nothing mechanically updates the duplicate at version-bump time.** Whenever governance owns the canonical version (pyproject.toml), any other place that names a version must either be mechanically regenerated from that canonical OR read it at runtime.
+
+### Countermeasure
+
+Two-layer fix:
+
+1. **Immediate (this hotfix)**: replace the hardcoded literal with runtime lookup:
+   ```python
+   from importlib import metadata
+   try:
+       __version__ = metadata.version("qor-logic")
+   except metadata.PackageNotFoundError:
+       __version__ = "0+unknown"
+   ```
+   Once-and-done; future bumps never need a cli.py edit.
+
+2. **Regression guard (this hotfix)**: `tests/test_cli_version_from_metadata.py` carries two tests:
+   - `test_cli_version_matches_package_metadata`: asserts module-level `__version__` agrees with `importlib.metadata.version("qor-logic")`.
+   - `test_cli_version_not_hardcoded_literal`: Rule-4 structural lint — `cli.py` source must not carry a SemVer-shaped string literal on any `__version__ = ...` line. Prevents regression to hardcoding.
+
+3. **Future Phase 35 candidate**: extend the Rule-4 structural lint to ALL source files — grep for SemVer-shaped string literals outside `pyproject.toml`, `CHANGELOG.md`, `META_LEDGER.md`, and `SHADOW_GENOME.md` (the legitimate holders of historical version strings). Any match in `qor/**/*.py` that's not fetching from metadata becomes a seal-time failure. Catches any future hardcoded-version creep across the codebase in one sweep.
+
+### Pattern ID
+
+SG-Phase34-A (hardcoded version drift: module-level constant duplicating pyproject version drifted across six releases because nothing mechanically coupled the two)
+
+---
+
 *Shadow integrity: ACTIVE*

--- a/docs/plan-qor-phase34-cli-version-hotfix.md
+++ b/docs/plan-qor-phase34-cli-version-hotfix.md
@@ -1,0 +1,44 @@
+# Plan: Phase 34 — CLI `__version__` hotfix
+
+**change_class**: hotfix
+**target_version**: v0.24.1
+**doc_tier**: minimal
+**terms_introduced**: none
+
+## Context
+
+`qor/cli.py:13` hardcodes `__version__ = "0.18.0"`. The string has not been updated across v0.18.0 → v0.24.0 (six releases). `pip show qor-logic` reports the correct version (`0.24.0`) because it reads pyproject; `qorlogic --version` reports `0.18.0` because it reads the hardcoded constant. Same family as SG-Phase32-B (README) and SG-Phase33-A (seal-tag): state duplicated away from source of truth, drifts silently.
+
+## Phase 1: Single fix + regression guard
+
+### Unit Tests (TDD — already green post-fix)
+
+- `tests/test_cli_version_from_metadata.py` — NEW
+  - `test_cli_version_matches_package_metadata`: asserts `qor.cli.__version__ == importlib.metadata.version("qor-logic")`.
+  - `test_cli_version_not_hardcoded_literal`: Rule-4 structural guard — `cli.py` must not carry a `"X.Y.Z"` SemVer literal on any `__version__ = ...` line. Prevents regression to hardcoding.
+
+### Affected Files
+
+- `tests/test_cli_version_from_metadata.py` (NEW)
+- `qor/cli.py` — remove hardcoded `__version__ = "0.18.0"`; read via `importlib.metadata.version("qor-logic")` with `PackageNotFoundError` fallback to `"0+unknown"`.
+- `docs/SHADOW_GENOME.md` — Entry #24 SG-Phase34-A.
+
+### Changes
+
+```python
+# qor/cli.py (imports updated)
+from importlib import metadata
+
+try:
+    __version__ = metadata.version("qor-logic")
+except metadata.PackageNotFoundError:
+    __version__ = "0+unknown"
+```
+
+## CI Validation
+
+```bash
+python -m pytest tests/test_cli_version_from_metadata.py -q
+python -m pytest -q  # full suite stays green
+qorlogic --version  # should print installed version, not "0.18.0"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qor-logic"
-version = "0.24.0"
+version = "0.24.1"
 description = "QorLogic S.H.I.E.L.D. governance skills for Claude Code, Kilo Code, and future AI coding hosts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/qor/cli.py
+++ b/qor/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+from importlib import metadata
 from pathlib import Path
 
 from qor.install import (
@@ -10,7 +11,10 @@ from qor.install import (
     _do_uninstall,
 )
 
-__version__ = "0.18.0"
+try:
+    __version__ = metadata.version("qor-logic")
+except metadata.PackageNotFoundError:
+    __version__ = "0+unknown"
 
 
 def _default_dist_root() -> Path:

--- a/qor/dist/manifest.json
+++ b/qor/dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-04-19T00:12:58Z",
+  "generated_ts": "2026-04-19T00:36:53Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/dist/variants/claude/manifest.json
+++ b/qor/dist/variants/claude/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-04-19T00:12:58Z",
+  "generated_ts": "2026-04-19T00:36:53Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/dist/variants/codex/manifest.json
+++ b/qor/dist/variants/codex/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-04-19T00:12:58Z",
+  "generated_ts": "2026-04-19T00:36:53Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/dist/variants/gemini/manifest.json
+++ b/qor/dist/variants/gemini/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-04-19T00:12:58Z",
+  "generated_ts": "2026-04-19T00:36:53Z",
   "files": [
     {
       "id": "agent-agent-architect.toml",

--- a/qor/dist/variants/kilo-code/manifest.json
+++ b/qor/dist/variants/kilo-code/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-04-19T00:12:58Z",
+  "generated_ts": "2026-04-19T00:36:53Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/tests/test_cli_version_from_metadata.py
+++ b/tests/test_cli_version_from_metadata.py
@@ -1,0 +1,37 @@
+"""Regression guard: qor.cli.__version__ must match the installed package
+metadata version, not a hardcoded string.
+
+SG-Phase34-A: stale hardcoded versions across six releases (v0.18.0 -
+v0.24.0) because the CLI kept a string literal that nothing mechanically
+updated on bump. Fix: read via importlib.metadata at module load.
+"""
+from __future__ import annotations
+
+from importlib import metadata
+
+import qor.cli as cli
+
+
+def test_cli_version_matches_package_metadata():
+    expected = metadata.version("qor-logic")
+    assert cli.__version__ == expected, (
+        f"qor.cli.__version__ ({cli.__version__!r}) diverged from "
+        f"importlib.metadata.version('qor-logic') ({expected!r}). "
+        "Do not hardcode the version in cli.py -- read it from package metadata."
+    )
+
+
+def test_cli_version_not_hardcoded_literal():
+    """Rule-4 structural guard: cli.py source must not carry a
+    SemVer-shaped string literal on the __version__ line."""
+    import re
+    from pathlib import Path
+
+    src = Path(cli.__file__).read_text(encoding="utf-8")
+    for line in src.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("__version__"):
+            assert not re.search(r'"\d+\.\d+\.\d+"', stripped), (
+                f"cli.py carries a hardcoded version literal: {stripped!r}. "
+                "Use importlib.metadata.version('qor-logic') instead."
+            )


### PR DESCRIPTION
## Summary

**Plan**: [`docs/plan-qor-phase34-cli-version-hotfix.md`](docs/plan-qor-phase34-cli-version-hotfix.md)
**Ledger Entry**: #114
**Merkle Seal**: `a840c3b5eb03e69096e52ce898bb9988c67311f0bd046feaea102bd0681e8d3a`
**Tag**: `v0.24.1` → commit `d2b11c9` (pyproject `0.24.1` — Phase 33 wiring holding on second live exercise)

`qor/cli.py` hardcoded `__version__ = "0.18.0"` and never got updated across six releases. `qorlogic --version` printed `0.18.0` on every install since v0.18.0 including v0.24.0. Third recurrence of the "state duplicated away from source of truth" pattern:

- SG-Phase32-B: README `## What's new in v0.22.0` survived to v0.23.0
- SG-Phase33-A: annotated tags pointed at pre-seal HEAD (v0.19.0–v0.22.0 off-by-one)
- SG-Phase34-A (this): CLI `__version__` literal drifted across six releases

## Fix

- `qor/cli.py`: `__version__ = importlib.metadata.version("qor-logic")` at import time. `PackageNotFoundError` falls back to `"0+unknown"` for uninstalled source checkouts.
- `tests/test_cli_version_from_metadata.py`:
  - `test_cli_version_matches_package_metadata` — runtime parity.
  - `test_cli_version_not_hardcoded_literal` — Rule-4 structural lint forbidding SemVer literals on `__version__` lines. Prevents regression.

## Test Plan

- [x] 638 tests passing on two consecutive runs (+2 new)
- [x] `qorlogic --version` post-install will report the package metadata version, no longer stale
- [x] Phase 33 seal-tag timing fix proven again: v0.24.1 tag targets the post-seal commit
- [ ] Phase 35 candidate (not in this PR): extend the Rule-4 structural lint to ALL source files — catch any future hardcoded-version string outside pyproject/CHANGELOG/META_LEDGER/SHADOW_GENOME in one sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)