### PR TITLE
fix: release workflow main-reachability guard (v0.28.1)

### DIFF
--- a/.agent/staging/AUDIT_REPORT.md
+++ b/.agent/staging/AUDIT_REPORT.md
@@ -1,8 +1,8 @@
-# Gate Tribunal Audit Report — Phase 38 Pass 1
+# Gate Tribunal Audit Report — Phase 40 Pass 1
 
-**Plan**: `docs/plan-qor-phase38-ci-commands-schema-slot.md`
-**change_class**: feature
-**target_version**: v0.28.0
+**Plan**: `docs/plan-qor-phase40-release-workflow-guard.md`
+**change_class**: hotfix
+**target_version**: v0.28.1
 **Verdict**: **PASS**
 **Mode**: solo
 **Tribunal Date**: 2026-04-20
@@ -12,61 +12,51 @@
 
 ## Executive summary
 
-Trivial-scope plan: one schema property addition + one skill-template section + one 6-test file. No infrastructure risk. Applies the Phase 37 Infrastructure Alignment discipline as baseline; all three target files exist and insertion points are legal.
+Hotfix scope: one `release.yml` step addition + one structural-lint test file. Closes a latent defect that allowed pre-merge PyPI publishes (historical: v0.24.1, v0.25.0, v0.28.0 all shipped from open PR branches). The guard uses `git merge-base --is-ancestor` — safe, portable, no new dependencies.
 
 ## Audit passes
 
-### Security / OWASP / Ghost UI — N/A / PASS
+### Security / OWASP / Ghost UI — PASS / N/A
 
-Schema-data change only. No runtime surface, no auth, no subprocess.
-
-### Section 4 Razor Pass — PASS
-
-| Check | Plan | Status |
-|---|---|---|
-| Max function lines | N/A (no new code) | OK |
-| Max file lines | new test file ~80 LOC | OK |
-| Plan scope | 1 schema delta + 1 skill edit + 1 test file | OK |
+The guard step runs `git merge-base --is-ancestor` with no user-input interpolation; uses only `$GITHUB_SHA` and a literal `origin/main` ref. No injection surface.
 
 ### Dependency Audit — PASS
 
 No new packages.
 
+### Section 4 Razor Pass — PASS
+
+Workflow YAML addition: ~8 lines. Test file: ~50 LOC, two functions. Well under any limit.
+
 ### Macro-Level Architecture Pass — PASS
 
-- `plan.schema.json` addition is additive; field lands at top-level properties + required.
-- `/qor-plan` SKILL.md template edit is additive to §Plan Structure.
-- Grandfathering rule handled at test layer via phase-number regex — no schema conditional needed.
-- Gate artifact payloads emitted by `/qor-plan` in Phase 36/37 already included `ci_commands`; schema now enforces what practice already does.
+Guard placement (immediately after checkout, before build) is correct: fails fast before any artifact is produced or uploaded. Idempotent; fetches main ref freshly each run.
 
-### Infrastructure Alignment Pass (Phase 37 discipline, live) — PASS
+### Infrastructure Alignment Pass — PASS
 
-- `qor/gates/schema/plan.schema.json` — exists ✓
-- `qor/skills/sdlc/qor-plan/SKILL.md` §Plan Structure — exists ✓
-- `tests/test_plan_schema_ci_commands.py` — declared NEW ✓
-- No undeclared dependencies; no filesystem claims beyond the three files listed.
+- `.github/workflows/release.yml` exists with `fetch-depth: 0` on checkout step (verified).
+- `pypa/gh-action-pypi-publish` step exists as the insertion anchor for the guard (verified).
+- No skill files modified (matrix handoff count unchanged).
 
 ### Orphan Detection — PASS
 
-All three files are either existing (schema, skill) or explicitly declared NEW (test).
+Test file lands in `tests/`. Workflow edit is to an existing file. Clean.
+
+## Observation
+
+Bootstrap note: this hotfix's own tag push (v0.28.1) will trigger the workflow with the NEW guard logic active at that ref. If the tag is pushed before PR-to-main merge, the guard will correctly block publish — preventing this very class of failure for its own release. The guard is self-enforcing from the moment the tag is pushed.
 
 ## Signature / cycle
 
-- Pass 1 signature: `[]` (PASS, no findings)
-- Cycle count for Phase 38: 1 → PASS on first pass.
-
-## Chain position
-
-- Plan artifact: `.qor/gates/<sid>/plan.json` (Pass 1, valid)
-- Audit artifact: to be written
-- Next: `/qor-implement` unblocked.
+- Pass 1 signature: `[]`
+- Cycle count: 1 → PASS on first pass.
 
 ## Required next action
 
-**`/qor-implement`** — single-phase trivial implementation.
+**`/qor-implement`** — single-step workflow change.
 
 ---
 
 *Verdict: PASS (L1)*
 *Mode: solo*
-*Phase 38 Pass 1 cleared on first pass — consistent with Phase 37's first-pass PASS under the same Infrastructure Alignment discipline.*
+*Hotfix scope, PASS on first pass.*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,13 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: Verify tag reachable from main
+        run: |
+          git fetch origin main --depth=100
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA} which is not reachable from origin/main. Publish refused. Merge the tag's commit to main before tagging for release."
+            exit 1
+          fi
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -4894,6 +4894,42 @@ User direction on prior turn was implement. V10 blocks implement. Judge does not
 *Session: SEALED* (Phase 38 substantiated — **FREEZE LINE**)
 *Merkle seal: b7c8ed67...* (Phase 38 seal on top of Phase 37's 401a37cd; Entries #116-#132 chained)
 
+---
+
+### Entry #133: SESSION SEAL -- Phase 40 hotfix substantiated
+
+**Timestamp**: 2026-04-20
+**Phase**: SEAL (hotfix)
+**Author**: Judge
+**Verdict**: PASS (713 tests green on 2 consecutive runs)
+
+**Target**: `docs/plan-qor-phase40-release-workflow-guard.md`
+**Change Class**: `hotfix`
+**Version**: `0.28.0 -> 0.28.1`
+**Tag**: `v0.28.1` (created at Step 9.5.5 post-commit, LOCAL ONLY pending PR merge)
+
+**Content Hash**: `fbdfe2ceb06e017be18a6bc190be8459962380091ee97fd34b1b56e3830b482b`
+**Previous Hash**: `b7c8ed6798f760560e9e747c17a69919ae7e248e018cddfbd7042dcb84401737`
+**Chain Hash (Merkle seal)**: `dea2e42906182f44ec084fe44b81111ae6d428006aa1d4018da608a20f104311`
+
+**Scope**: Closes the pre-merge-publish defect in `.github/workflows/release.yml`. Adds a main-reachability guard step between checkout and build; blocks publish when `$GITHUB_SHA` is not an ancestor of `origin/main`. Historical incidents (v0.24.1, v0.25.0, v0.28.0 all published from open PR branches) cannot recur under the new guard.
+
+**Bootstrap note**: v0.28.1's own tag push will fire the workflow with the new guard active. If pushed pre-merge, the guard will correctly block publish — self-enforcing. Operator must merge PR first, then push (or re-tag onto) the merge commit for PyPI publish to proceed.
+
+**Deploy protocol (post-merge)**:
+1. Push `phase/40-release-workflow-guard` branch to origin.
+2. Open PR #9 targeting main.
+3. Merge PR.
+4. After merge, push `v0.28.1` tag (or re-tag onto merge commit) — workflow fires, guard passes (tag now on main), PyPI publishes.
+
+**Decision**: Phase 40 hotfix sealed at v0.28.1. Tag LOCAL ONLY until PR merge per the new doctrine this hotfix is establishing.
+
+---
+
+*Chain integrity: VALID*
+*Session: SEALED* (Phase 40 hotfix substantiated)
+*Merkle seal: dea2e429...* (Phase 40 seal on top of Phase 38's b7c8ed67; Entries #116-#133 chained)
+
 
 
 

--- a/docs/plan-qor-phase40-release-workflow-guard.md
+++ b/docs/plan-qor-phase40-release-workflow-guard.md
@@ -1,0 +1,50 @@
+# Plan: Phase 40 — release workflow main-reachability guard
+
+**change_class**: hotfix
+**target_version**: v0.28.1
+**doc_tier**: minimal
+**pass**: 1
+
+**Scope**: One workflow-step addition. Hotfix for pre-existing latent defect that allowed pre-merge publishes to PyPI for v0.24.1, v0.25.0, and v0.28.0.
+
+**Rationale**: `.github/workflows/release.yml` publishes to PyPI on any `v*.*.*` tag push, with no check that the tag's commit is reachable from `origin/main`. This allowed tags pushed from unmerged branches to ship to PyPI. Historical incidents: v0.24.1 (PR #6 open), v0.25.0 (PR #7 open), v0.28.0 (PR #8 open at push time). The procedural-surface freeze established in v0.28.0 is undermined if workflow gates are absent.
+
+## Open Questions
+
+None.
+
+## Phase 1 — workflow guard
+
+### Affected Files
+
+- `.github/workflows/release.yml` — add "Verify tag reachable from main" step immediately after `actions/checkout@v4`, before any publish step.
+- `tests/test_release_workflow_guard.py` — NEW. Structural lint: workflow file contains the guard step.
+
+### Changes
+
+`release.yml` step addition (after `actions/checkout@v4`, before `python -m build`):
+
+```yaml
+      - name: Verify tag reachable from main
+        run: |
+          git fetch origin main --depth=100
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA} which is not reachable from origin/main. Publish refused."
+            exit 1
+          fi
+```
+
+- `fetch-depth: 0` on the checkout step already ensures full history is present; `git fetch origin main` refreshes the main ref.
+- `merge-base --is-ancestor` exits 0 iff `$GITHUB_SHA` is an ancestor of `origin/main` (i.e., the tag's commit has been merged to main).
+- On failure, the job exits non-zero with a clear `::error::` annotation. No PyPI upload occurs because subsequent steps do not run.
+
+### Unit Tests (TDD — written first)
+
+- `tests/test_release_workflow_guard.py::test_release_workflow_has_main_reachability_guard` — NEW. Parses `release.yml` as YAML; asserts the `build-and-publish` job contains a step whose `run` block calls `git merge-base --is-ancestor` against `origin/main`.
+- `tests/test_release_workflow_guard.py::test_release_workflow_guard_runs_before_publish` — NEW. Asserts the guard step's index in the job's `steps` list is less than the `pypa/gh-action-pypi-publish` step's index.
+
+## CI Commands
+
+- `pytest tests/test_release_workflow_guard.py` — targeted
+- `pytest` — full suite at seal
+- `python -m qor.reliability.gate_skill_matrix` — handoff integrity (no skill changes; should be unchanged)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qor-logic"
-version = "0.28.0"
+version = "0.28.1"
 description = "QorLogic S.H.I.E.L.D. governance skills for Claude Code, Kilo Code, and future AI coding hosts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/qor/dist/manifest.json
+++ b/qor/dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-04-20T15:28:33Z",
+  "generated_ts": "2026-04-20T16:09:40Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -96,7 +96,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/references/qor-audit-templates.md",
       "install_rel_path": "skills/qor-audit/references/qor-audit-templates.md",
-      "sha256": "8bc8c1a2ef6aac76d44bed95acbeae6ae3aa294a0fcc73a10bf8eb4fd5071dee"
+      "sha256": "6fdbf89d55c4ea2fad0b4382169cbb4b891643a873cc9f6e70c6f10b29efdd02"
     },
     {
       "id": "qor-audit",

--- a/qor/dist/variants/claude/manifest.json
+++ b/qor/dist/variants/claude/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-04-20T15:28:33Z",
+  "generated_ts": "2026-04-20T16:09:40Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -96,7 +96,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/references/qor-audit-templates.md",
       "install_rel_path": "skills/qor-audit/references/qor-audit-templates.md",
-      "sha256": "8bc8c1a2ef6aac76d44bed95acbeae6ae3aa294a0fcc73a10bf8eb4fd5071dee"
+      "sha256": "6fdbf89d55c4ea2fad0b4382169cbb4b891643a873cc9f6e70c6f10b29efdd02"
     },
     {
       "id": "qor-audit",

--- a/qor/dist/variants/codex/manifest.json
+++ b/qor/dist/variants/codex/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-04-20T15:28:33Z",
+  "generated_ts": "2026-04-20T16:09:40Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -96,7 +96,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/references/qor-audit-templates.md",
       "install_rel_path": "skills/qor-audit/references/qor-audit-templates.md",
-      "sha256": "8bc8c1a2ef6aac76d44bed95acbeae6ae3aa294a0fcc73a10bf8eb4fd5071dee"
+      "sha256": "6fdbf89d55c4ea2fad0b4382169cbb4b891643a873cc9f6e70c6f10b29efdd02"
     },
     {
       "id": "qor-audit",

--- a/qor/dist/variants/gemini/manifest.json
+++ b/qor/dist/variants/gemini/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-04-20T15:28:33Z",
+  "generated_ts": "2026-04-20T16:09:40Z",
   "files": [
     {
       "id": "agent-agent-architect.toml",

--- a/qor/dist/variants/kilo-code/manifest.json
+++ b/qor/dist/variants/kilo-code/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-04-20T15:28:33Z",
+  "generated_ts": "2026-04-20T16:09:40Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -96,7 +96,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/references/qor-audit-templates.md",
       "install_rel_path": "skills/qor-audit/references/qor-audit-templates.md",
-      "sha256": "8bc8c1a2ef6aac76d44bed95acbeae6ae3aa294a0fcc73a10bf8eb4fd5071dee"
+      "sha256": "6fdbf89d55c4ea2fad0b4382169cbb4b891643a873cc9f6e70c6f10b29efdd02"
     },
     {
       "id": "qor-audit",

--- a/tests/test_release_workflow_guard.py
+++ b/tests/test_release_workflow_guard.py
@@ -1,0 +1,57 @@
+"""Tests for release.yml main-reachability guard (Phase 40 hotfix).
+
+Prevents the pre-merge publish class of failure that shipped v0.24.1, v0.25.0,
+and v0.28.0 to PyPI from open-PR branches before they were merged to main.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+
+_WORKFLOW = pathlib.Path(".github/workflows/release.yml")
+
+
+def _load_job_steps() -> list[dict]:
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["build-and-publish"]["steps"]
+
+
+def _guard_step_index(steps: list[dict]) -> int | None:
+    for idx, step in enumerate(steps):
+        run = step.get("run", "")
+        if "merge-base --is-ancestor" in run and "origin/main" in run:
+            return idx
+    return None
+
+
+def _publish_step_index(steps: list[dict]) -> int | None:
+    for idx, step in enumerate(steps):
+        uses = step.get("uses", "")
+        if uses.startswith("pypa/gh-action-pypi-publish"):
+            return idx
+    return None
+
+
+def test_release_workflow_has_main_reachability_guard():
+    """release.yml must contain a step that runs git merge-base --is-ancestor against origin/main."""
+    steps = _load_job_steps()
+    idx = _guard_step_index(steps)
+    assert idx is not None, (
+        "release.yml is missing the main-reachability guard step. "
+        "Expected a run block containing 'git merge-base --is-ancestor' and 'origin/main'."
+    )
+
+
+def test_release_workflow_guard_runs_before_publish():
+    """The guard must precede the PyPI publish step so a failing guard blocks upload."""
+    steps = _load_job_steps()
+    guard = _guard_step_index(steps)
+    publish = _publish_step_index(steps)
+    assert guard is not None, "guard step absent"
+    assert publish is not None, "publish step absent"
+    assert guard < publish, (
+        f"Guard step (index {guard}) must precede publish step (index {publish}). "
+        "Otherwise a failing guard does not block the upload."
+    )


### PR DESCRIPTION
## Summary

Hotfix for the pre-merge PyPI publish defect. Adds a main-reachability guard to `.github/workflows/release.yml` so that tag pushes from unmerged branches cannot publish to PyPI.

**Plan**: `docs/plan-qor-phase40-release-workflow-guard.md`
**Ledger entry**: **#133**
**Merkle seal**: `dea2e42906182f44ec084fe44b81111ae6d428006aa1d4018da608a20f104311`
**Change class**: hotfix (v0.28.0 → v0.28.1)

## Problem

`.github/workflows/release.yml` triggered `pypa/gh-action-pypi-publish` on any `v*.*.*` tag push with no gate on main-branch reachability. Historical incidents:

- **v0.24.1** — published from PR #6 branch (never on main until consolidation)
- **v0.25.0** — published from PR #7 branch (never on main until consolidation)
- **v0.28.0** — published from PR #8 branch (before merge)

Operator just flagged this pattern — the consolidation PR #8's v0.28.0 went to PyPI before PR review could complete.

## Fix

New step between `actions/checkout@v4` and `python -m build`:

```yaml
      - name: Verify tag reachable from main
        run: |
          git fetch origin main --depth=100
          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
            echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA} which is not reachable from origin/main. Publish refused..."
            exit 1
          fi
```

`git merge-base --is-ancestor` exits 0 iff the tag's commit has been merged to main. On failure, the step exits non-zero with an `::error::` annotation; subsequent build + publish steps do not execute.

## Tests

`tests/test_release_workflow_guard.py` (2 structural lint tests):

- `test_release_workflow_has_main_reachability_guard` — workflow contains the guard run-block.
- `test_release_workflow_guard_runs_before_publish` — guard step index precedes publish step index.

Both would fail if the guard is removed or reordered.

## Bootstrap note

This hotfix's own `v0.28.1` tag push will trigger the workflow with the new guard active at that ref:

- If the tag is pushed **before** this PR merges: guard correctly blocks publish (tag not on main).
- Post-merge: operator pushes tag (or moves it to merge commit). Guard passes (tag now on main). Publish proceeds.

The guard is self-enforcing from the moment it ships.

## Test plan

- [x] 713 pytest tests green on 2 consecutive runs
- [x] Gate-skill matrix: 28 skills, 108 handoffs, 0 broken
- [x] Intent lock verified
- [x] `v0.28.1` tag created locally (NOT pushed; per new doctrine, pushed only after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)