### PR TITLE
feat(hooks): add gate_written observer channel (B24 from a sibling governance repository)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ file is the user-facing narrative.
 
 ## [Unreleased]
 
+### Added
+- **`gate_written` hook channel** (upstream contribution from FailSafe-Pro B24): consumers can observe every successful `write_gate_artifact` call via two pure-Python dispatch sources — Python entry-points under group `qor_logic.events.gate_written`, and project-local `<root>/.qor/hooks.yaml`. Hooks receive a frozen `GateWrittenEvent(phase, session_id, artifact_path, payload_sha256, ts)`. Exceptions are swallow-logged to `<root>/.qor/hooks/hooks.log` as JSONL; never propagate. Hooks are non-authoritative observers — the gate artifact is already persisted before any hook fires. Subprocess hooks use list-form argv and are bounded by a 30-second timeout. See `qor/references/hook-contract.md` for the full contract including trust model. Zero new runtime dependencies (reuses existing `PyYAML`).
+
 ## [0.28.0] - 2026-04-20
 
 Procedural surface freeze line. Consolidates phases 36-38 work into a single release: full SG-PlanAuditLoop-A countermeasure set (C1-C4) plus `ci_commands` plan-schema slot. Phase 39 (context-discipline + persona reshape) explicitly deferred pending upstream consumer lockdown.

--- a/qor/references/hook-contract.md
+++ b/qor/references/hook-contract.md
@@ -1,0 +1,103 @@
+# `gate_written` hook contract
+
+qor-logic fires a `gate_written` event after every successful call to
+`qor.scripts.gate_chain.write_gate_artifact`. Consumers can register
+handlers via two channels:
+
+1. **Python entry-points** (group `qor_logic.events.gate_written`) —
+   resolved once per process and cached.
+2. **Project-local config** at `<root>/.qor/hooks.yaml` — loaded on
+   every dispatch.
+
+The hook is a **non-authoritative observer**. The authoritative gate
+artifact is written to disk before any hook fires. Exceptions raised
+by hooks are swallowed and logged to `<root>/.qor/hooks/hooks.log`;
+they never abort the write.
+
+## Event payload
+
+```python
+@dataclass(frozen=True)
+class GateWrittenEvent:
+    phase: str              # "plan" | "audit" | "implement" | ...
+    session_id: str
+    artifact_path: Path     # absolute path to the written artifact
+    payload_sha256: str     # SHA-256 of artifact file bytes
+    ts: str                 # ISO-8601 UTC instant of the hook fire
+```
+
+## Entry-point registration (consumer `pyproject.toml`)
+
+```toml
+[project.entry-points."qor_logic.events.gate_written"]
+my-handler = "my_package.hooks:on_gate_written"
+```
+
+The referenced callable must accept a single `GateWrittenEvent`
+positional argument. Its return value is ignored.
+
+## Config-file format (`.qor/hooks.yaml`)
+
+```yaml
+gate_written:
+  # Python dotted-path: imported and invoked with the event.
+  - module: my_package.hooks:on_gate_written
+
+  # Shell command: argv list (no shell=True). The artifact path is
+  # appended as the final argv element.
+  - command: [/usr/local/bin/my-hook.sh]
+```
+
+YAML is parsed with `yaml.safe_load`; top-level keys other than
+`gate_written` are ignored. Missing file → no config hooks.
+
+## Invocation order
+
+1. All entry-point hooks run first, in the order returned by
+   `importlib.metadata.entry_points` (typically install order).
+2. Config-file hooks run next, top-to-bottom as declared.
+
+Each hook has a 30-second subprocess timeout (shell commands) or is
+invoked synchronously (Python callables). There is no concurrency
+between hooks — one completes before the next begins.
+
+## Log format
+
+On every fire attempt (success or error), one JSONL line is appended
+to `<root>/.qor/hooks/hooks.log`:
+
+```json
+{"ts":"2026-04-20T00:00:00Z","hook":"my-handler","event":{...},"status":"ok","duration_ms":3}
+```
+
+On error, a `"status":"error"` record includes a stringified
+`"exception"` field with the traceback.
+
+## Trust model
+
+**Shell commands and Python dotted paths in `.qor/hooks.yaml` run
+arbitrary code from the consumer's repo.** This matches the trust
+model of:
+
+- `.github/workflows/` (GitHub Actions)
+- `.pre-commit-config.yaml`
+- `Makefile` / `noxfile.py`
+- npm `package.json` `scripts.preinstall`
+
+If your team treats `.qor/hooks.yaml` as a security-sensitive file
+(review on every PR, code-owners, etc.), apply the same treatment
+as for those files. qor-logic does not sandbox, sign, or vet hooks.
+
+Entry-point registration is subject to the standard Python packaging
+trust model: any installed package can register in the
+`qor_logic.events.gate_written` group.
+
+## Performance
+
+With no hooks registered and no `.qor/hooks.yaml` present, the
+dispatch path is an `importlib.metadata.entry_points` lookup (cached
+after first call) plus a `Path.exists` check — sub-millisecond.
+
+Hook dispatch happens synchronously on the calling thread after the
+gate artifact has already been persisted, so slow hooks slow the skill
+but never risk artifact corruption.

--- a/qor/scripts/gate_chain.py
+++ b/qor/scripts/gate_chain.py
@@ -128,10 +128,38 @@ def write_gate_artifact(
     Phase 37 Phase 1: for audit artifacts, also append to the session's
     `audit_history.jsonl` after the singleton write succeeds. Singleton remains
     authoritative for chain gating; history log is advisory for stall detection.
+
+    B24: after the authoritative write succeeds, fires the `gate_written`
+    hook chain (entry-points + .qor/hooks.yaml). Hook exceptions are
+    swallow-logged; never propagated. See `qor/scripts/gate_hooks.py`.
     """
+    import hashlib
     sid = session_id or session.get_or_create()
     path = vga.write_artifact(phase, payload, session_id=sid)
     if phase == "audit":
         from qor.scripts import audit_history
         audit_history.append(payload, session_id=sid)
+    _fire_gate_written_hook(phase, sid, path)
     return path
+
+
+def _fire_gate_written_hook(phase: str, session_id: str, path: "Path") -> None:
+    """Invoke the hook dispatcher after a successful gate-artifact write.
+
+    Isolated so the authoritative write path never fails on hook errors:
+    any exception surfacing from dispatch is swallowed here too.
+    """
+    import hashlib
+    from qor.scripts import gate_hooks
+    try:
+        payload_bytes = path.read_bytes()
+        event = gate_hooks.GateWrittenEvent(
+            phase=phase,
+            session_id=session_id,
+            artifact_path=path,
+            payload_sha256=hashlib.sha256(payload_bytes).hexdigest(),
+            ts=shadow_process.now_iso(),
+        )
+        gate_hooks.dispatch_gate_written(event)
+    except BaseException:  # noqa: BLE001 — hooks must never break writes
+        pass

--- a/qor/scripts/gate_hooks.py
+++ b/qor/scripts/gate_hooks.py
@@ -1,0 +1,176 @@
+"""Gate-write hook dispatch (B24 — failsafe-pro issue).
+
+Non-authoritative observer channel fired after each successful
+`write_gate_artifact`. Two dispatch sources, both pure-Python:
+
+1. **Entry-points** under group ``qor_logic.events.gate_written`` —
+   installed packages register a callable via standard Python packaging
+   metadata.
+2. **Config-file** at ``<root>/.qor/hooks.yaml`` — project-local hooks
+   declared as Python dotted paths or shell command argv lists.
+
+Error semantics: swallow + log. Exceptions are caught, recorded as
+JSONL in ``<root>/.qor/hooks/hooks.log``, and never propagated to the
+caller. The authoritative governance path is the sentinel/ledger bridge
+(see ``crates/failsafe-sentinel/src/gate_watcher.rs`` downstream);
+hooks are observers only.
+
+Trust model: entries in ``.qor/hooks.yaml`` execute arbitrary code
+from the consumer's repo. See ``qor/references/hook-contract.md``.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import json
+import subprocess
+import sys
+import time
+import traceback
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from qor import workdir as _workdir
+
+ENTRY_POINT_GROUP = "qor_logic.events.gate_written"
+HOOK_TIMEOUT_SECONDS = 30
+
+_entry_point_cache: list["_HookTarget"] | None = None
+
+
+@dataclass(frozen=True)
+class GateWrittenEvent:
+    """Event payload fired after a successful gate-artifact write."""
+    phase: str
+    session_id: str
+    artifact_path: Path
+    payload_sha256: str
+    ts: str
+
+
+@dataclass(frozen=True)
+class _HookTarget:
+    """Internal: a resolved hook callable with its origin label."""
+    name: str
+    kind: str  # "callable" | "command"
+    callable: object | None  # Python callable for "callable" kind
+    argv: list[str] | None  # subprocess argv for "command" kind
+
+
+def reload_entry_points() -> None:
+    """Invalidate the entry-point cache. Tests only — production never calls."""
+    global _entry_point_cache
+    _entry_point_cache = None
+
+
+def dispatch_gate_written(event: GateWrittenEvent) -> None:
+    """Fire all registered hooks for `gate_written`. Swallow exceptions."""
+    targets = _enumerate_entry_points() + _load_config_file_hooks(_workdir.root())
+    if not targets:
+        return
+    log_path = _workdir.root() / ".qor" / "hooks" / "hooks.log"
+    for target in targets:
+        _invoke_hook_safely(target, event, log_path)
+
+
+def _enumerate_entry_points() -> list[_HookTarget]:
+    global _entry_point_cache
+    if _entry_point_cache is not None:
+        return _entry_point_cache
+    eps = importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)
+    targets = [
+        _HookTarget(name=ep.name, kind="callable", callable=ep.load(), argv=None)
+        for ep in eps
+    ]
+    _entry_point_cache = targets
+    return targets
+
+
+def _load_config_file_hooks(root: Path) -> list[_HookTarget]:
+    hooks_yaml = root / ".qor" / "hooks.yaml"
+    if not hooks_yaml.exists():
+        return []
+    try:
+        data = yaml.safe_load(hooks_yaml.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return []
+    entries = data.get("gate_written") or []
+    return [t for t in (_resolve_config_entry(idx, e) for idx, e in enumerate(entries)) if t]
+
+
+def _resolve_config_entry(idx: int, entry: dict) -> _HookTarget | None:
+    if not isinstance(entry, dict):
+        return None
+    if "module" in entry:
+        dotted = entry["module"]
+        try:
+            target = _import_dotted(dotted)
+        except (ImportError, AttributeError, ValueError):
+            return None
+        return _HookTarget(
+            name=f"config[{idx}]:{dotted}", kind="callable",
+            callable=target, argv=None,
+        )
+    if "command" in entry:
+        cmd = entry["command"]
+        if not isinstance(cmd, list) or not all(isinstance(a, str) for a in cmd):
+            return None
+        return _HookTarget(
+            name=f"config[{idx}]:{cmd[0]}", kind="command",
+            callable=None, argv=list(cmd),
+        )
+    return None
+
+
+def _import_dotted(dotted: str):
+    module_name, _, attr = dotted.partition(":")
+    if not attr:
+        raise ValueError(f"dotted path must use 'module:attr' form: {dotted!r}")
+    module = importlib.import_module(module_name)
+    return getattr(module, attr)
+
+
+def _invoke_hook_safely(target: _HookTarget, event: GateWrittenEvent, log_path: Path) -> None:
+    start = time.monotonic()
+    status, exception = "ok", None
+    try:
+        if target.kind == "callable":
+            target.callable(event)
+        else:
+            _run_command_hook(target, event)
+    except BaseException:  # noqa: BLE001 — swallow-log by design
+        status = "error"
+        exception = traceback.format_exc()
+    duration_ms = int((time.monotonic() - start) * 1000)
+    _append_log(log_path, target.name, event, status, duration_ms, exception)
+
+
+def _run_command_hook(target: _HookTarget, event: GateWrittenEvent) -> None:
+    argv = list(target.argv or []) + [str(event.artifact_path)]
+    subprocess.run(
+        argv, check=False, capture_output=True,
+        timeout=HOOK_TIMEOUT_SECONDS,
+    )
+
+
+def _append_log(
+    log_path: Path, hook_name: str, event: GateWrittenEvent,
+    status: str, duration_ms: int, exception: str | None,
+) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    event_dict = asdict(event)
+    event_dict["artifact_path"] = str(event.artifact_path)
+    record = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "hook": hook_name,
+        "event": event_dict,
+        "status": status,
+        "duration_ms": duration_ms,
+    }
+    if exception is not None:
+        record["exception"] = exception
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")

--- a/tests/test_gate_hooks_config_file.py
+++ b/tests/test_gate_hooks_config_file.py
@@ -1,0 +1,91 @@
+"""Config-file dispatch: .qor/hooks.yaml maps event -> [{module|command}].
+
+Python dotted-path entries are imported and called. Shell entries are
+run via subprocess with artifact path appended to argv. Both write
+an entry to .qor/hooks/hooks.log on success (failure covered by
+test_gate_hooks_swallow.py).
+"""
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import sys
+from pathlib import Path
+
+from qor.scripts import gate_hooks
+
+
+def _make_event(tmp_path: Path) -> gate_hooks.GateWrittenEvent:
+    artifact = tmp_path / ".qor" / "gates" / "s1" / "plan.json"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("{}", encoding="utf-8")
+    return gate_hooks.GateWrittenEvent(
+        phase="plan",
+        session_id="s1",
+        artifact_path=artifact,
+        payload_sha256="beefdead",
+        ts="2026-04-20T00:00:00Z",
+    )
+
+
+_config_hook_calls: list[gate_hooks.GateWrittenEvent] = []
+
+
+def _config_hook(event):
+    """Dotted-path target loaded via the config-file hook."""
+    _config_hook_calls.append(event)
+
+
+def test_dotted_path_hook_invoked(monkeypatch, tmp_path):
+    _config_hook_calls.clear()
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points", lambda group=None: [],
+    )
+    gate_hooks.reload_entry_points()
+    monkeypatch.setenv("QOR_ROOT", str(tmp_path))
+    dotted = f"{__name__}:_config_hook"
+    hooks_yaml = tmp_path / ".qor" / "hooks.yaml"
+    hooks_yaml.parent.mkdir(parents=True, exist_ok=True)
+    hooks_yaml.write_text(
+        f"gate_written:\n  - module: {dotted}\n",
+        encoding="utf-8",
+    )
+
+    event = _make_event(tmp_path)
+    gate_hooks.dispatch_gate_written(event)
+
+    assert len(_config_hook_calls) == 1
+    log_path = tmp_path / ".qor" / "hooks" / "hooks.log"
+    assert log_path.exists()
+    entries = [json.loads(line) for line in log_path.read_text().splitlines() if line]
+    assert entries[-1]["status"] == "ok"
+    assert entries[-1]["event"]["phase"] == "plan"
+
+
+def test_shell_command_hook_invoked(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points", lambda group=None: [],
+    )
+    gate_hooks.reload_entry_points()
+    monkeypatch.setenv("QOR_ROOT", str(tmp_path))
+
+    marker = tmp_path / "shell_hook_ran.txt"
+    script = tmp_path / "hook.py"
+    script.write_text(
+        "import sys, pathlib\n"
+        f"pathlib.Path({str(marker)!r}).write_text(sys.argv[1])\n",
+        encoding="utf-8",
+    )
+    hooks_yaml = tmp_path / ".qor" / "hooks.yaml"
+    hooks_yaml.parent.mkdir(parents=True, exist_ok=True)
+    hooks_yaml.write_text(
+        "gate_written:\n"
+        f"  - command: [{sys.executable!r}, {str(script)!r}]\n",
+        encoding="utf-8",
+    )
+
+    event = _make_event(tmp_path)
+    gate_hooks.dispatch_gate_written(event)
+
+    assert marker.exists()
+    assert str(event.artifact_path) in marker.read_text()

--- a/tests/test_gate_hooks_entry_points.py
+++ b/tests/test_gate_hooks_entry_points.py
@@ -1,0 +1,79 @@
+"""Entry-point dispatch: registered callables fire once per gate write.
+
+Cache behavior: `reload_entry_points()` is the explicit invalidation knob;
+production never calls it. Second dispatch in a process reuses the cached
+enumeration.
+"""
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+from unittest.mock import patch
+
+from qor.scripts import gate_hooks
+
+
+def _make_event(tmp_path: Path) -> gate_hooks.GateWrittenEvent:
+    return gate_hooks.GateWrittenEvent(
+        phase="plan",
+        session_id="s1",
+        artifact_path=tmp_path / ".qor" / "gates" / "s1" / "plan.json",
+        payload_sha256="deadbeef",
+        ts="2026-04-20T00:00:00Z",
+    )
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, target):
+        self.name = name
+        self._target = target
+        self.group = gate_hooks.ENTRY_POINT_GROUP
+
+    def load(self):
+        return self._target
+
+
+def test_entry_point_hook_invoked_once(monkeypatch, tmp_path):
+    calls = []
+
+    def hook(event):
+        calls.append(event)
+
+    ep = _FakeEntryPoint("test-hook", hook)
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points",
+        lambda group=None: [ep] if group == gate_hooks.ENTRY_POINT_GROUP else [],
+    )
+    gate_hooks.reload_entry_points()
+    monkeypatch.setenv("QOR_ROOT", str(tmp_path))
+
+    event = _make_event(tmp_path)
+    gate_hooks.dispatch_gate_written(event)
+
+    assert len(calls) == 1
+    assert calls[0] is event
+
+
+def test_second_dispatch_uses_cached_entry_points(monkeypatch, tmp_path):
+    call_log = []
+
+    def hook(event):
+        call_log.append(event.phase)
+
+    ep = _FakeEntryPoint("cache-hook", hook)
+    enumerate_calls = {"n": 0}
+
+    def fake_entry_points(group=None):
+        enumerate_calls["n"] += 1
+        return [ep] if group == gate_hooks.ENTRY_POINT_GROUP else []
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    gate_hooks.reload_entry_points()
+    monkeypatch.setenv("QOR_ROOT", str(tmp_path))
+
+    gate_hooks.dispatch_gate_written(_make_event(tmp_path))
+    gate_hooks.dispatch_gate_written(_make_event(tmp_path))
+
+    assert len(call_log) == 2
+    # Cache should mean only one real enumeration call after reload.
+    assert enumerate_calls["n"] == 1

--- a/tests/test_gate_hooks_no_hooks_file.py
+++ b/tests/test_gate_hooks_no_hooks_file.py
@@ -1,0 +1,30 @@
+"""No hooks registered or configured: dispatch is a no-op.
+
+No .qor/hooks/ directory is created when nothing fires.
+"""
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+
+from qor.scripts import gate_hooks
+
+
+def test_no_hooks_is_noop(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points", lambda group=None: [],
+    )
+    gate_hooks.reload_entry_points()
+    monkeypatch.setenv("QOR_ROOT", str(tmp_path))
+
+    event = gate_hooks.GateWrittenEvent(
+        phase="plan",
+        session_id="s1",
+        artifact_path=tmp_path / ".qor" / "gates" / "s1" / "plan.json",
+        payload_sha256="x",
+        ts="2026-04-20T00:00:00Z",
+    )
+
+    gate_hooks.dispatch_gate_written(event)
+
+    assert not (tmp_path / ".qor" / "hooks").exists()

--- a/tests/test_gate_hooks_ordering.py
+++ b/tests/test_gate_hooks_ordering.py
@@ -1,0 +1,62 @@
+"""Ordering: entry-points run first (registration order), then config-file
+entries (file order). Captured in a shared list.
+"""
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+
+from qor.scripts import gate_hooks
+
+
+_order: list[str] = []
+
+
+def _ep1(event): _order.append("ep1")
+def _ep2(event): _order.append("ep2")
+def _cfg1(event): _order.append("cfg1")
+def _cfg2(event): _order.append("cfg2")
+
+
+class _FakeEntryPoint:
+    def __init__(self, name, target):
+        self.name = name
+        self._target = target
+        self.group = gate_hooks.ENTRY_POINT_GROUP
+
+    def load(self):
+        return self._target
+
+
+def _make_event(tmp_path: Path) -> gate_hooks.GateWrittenEvent:
+    return gate_hooks.GateWrittenEvent(
+        phase="plan",
+        session_id="s1",
+        artifact_path=tmp_path / ".qor" / "gates" / "s1" / "plan.json",
+        payload_sha256="beef",
+        ts="2026-04-20T00:00:00Z",
+    )
+
+
+def test_entry_points_before_config_file(monkeypatch, tmp_path):
+    _order.clear()
+    eps = [_FakeEntryPoint("ep1", _ep1), _FakeEntryPoint("ep2", _ep2)]
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points",
+        lambda group=None: eps if group == gate_hooks.ENTRY_POINT_GROUP else [],
+    )
+    gate_hooks.reload_entry_points()
+    monkeypatch.setenv("QOR_ROOT", str(tmp_path))
+
+    hooks_yaml = tmp_path / ".qor" / "hooks.yaml"
+    hooks_yaml.parent.mkdir(parents=True, exist_ok=True)
+    hooks_yaml.write_text(
+        f"gate_written:\n"
+        f"  - module: {__name__}:_cfg1\n"
+        f"  - module: {__name__}:_cfg2\n",
+        encoding="utf-8",
+    )
+
+    gate_hooks.dispatch_gate_written(_make_event(tmp_path))
+
+    assert _order == ["ep1", "ep2", "cfg1", "cfg2"]

--- a/tests/test_gate_hooks_swallow.py
+++ b/tests/test_gate_hooks_swallow.py
@@ -1,0 +1,57 @@
+"""Swallow-log: a hook that raises must not abort write_gate_artifact.
+
+The exception is recorded in .qor/hooks/hooks.log as a structured JSONL
+line with status="error", and dispatch returns normally.
+"""
+from __future__ import annotations
+
+import importlib.metadata
+import json
+from pathlib import Path
+
+from qor.scripts import gate_hooks
+
+
+def _make_event(tmp_path: Path) -> gate_hooks.GateWrittenEvent:
+    return gate_hooks.GateWrittenEvent(
+        phase="plan",
+        session_id="s1",
+        artifact_path=tmp_path / ".qor" / "gates" / "s1" / "plan.json",
+        payload_sha256="deadbeef",
+        ts="2026-04-20T00:00:00Z",
+    )
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, target):
+        self.name = name
+        self._target = target
+        self.group = gate_hooks.ENTRY_POINT_GROUP
+
+    def load(self):
+        return self._target
+
+
+def test_raising_hook_is_swallowed_and_logged(monkeypatch, tmp_path):
+    def bad_hook(event):
+        raise RuntimeError("boom")
+
+    ep = _FakeEntryPoint("bad-hook", bad_hook)
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points",
+        lambda group=None: [ep] if group == gate_hooks.ENTRY_POINT_GROUP else [],
+    )
+    gate_hooks.reload_entry_points()
+    monkeypatch.setenv("QOR_ROOT", str(tmp_path))
+
+    # Dispatch must not raise.
+    gate_hooks.dispatch_gate_written(_make_event(tmp_path))
+
+    log_path = tmp_path / ".qor" / "hooks" / "hooks.log"
+    assert log_path.exists()
+    lines = [json.loads(line) for line in log_path.read_text().splitlines() if line]
+    assert len(lines) == 1
+    assert lines[0]["status"] == "error"
+    assert lines[0]["hook"] == "bad-hook"
+    assert "RuntimeError" in lines[0]["exception"]
+    assert "boom" in lines[0]["exception"]


### PR DESCRIPTION
## Summary

Adds a pure-Python hook dispatch layer fired after every successful `write_gate_artifact` call. Two opt-in dispatch sources:

1. **Entry-points** under group `qor_logic.events.gate_written` — installed Python packages register a callable via standard packaging metadata.
2. **Project-local config** at `<root>/.qor/hooks.yaml` — Python dotted-path entries or subprocess argv lists (list-form only, no `shell=True`).

Hooks are **non-authoritative observers**: the gate artifact is persisted to disk before any hook fires. Exceptions are swallowed and recorded as JSONL in `<root>/.qor/hooks/hooks.log`; never propagated. Subprocess hooks have a 30-second timeout.

## Motivation

Contributed by a sibling governance repository's B24 backlog item. a sibling governance repository currently bridges qor-logic gate artifacts into its governance ledger via a filesystem watcher (polling model). This PR adds an explicit push-channel so observers don't have to poll.

The hook is a **contribution of the API surface**, not a replacement for the existing watcher. A downstream consumer package (`<consumer>-qor-hook`) ships in the same release cycle as a proof-of-life that the contract works end-to-end.

## Design principles

- **Pure Python**: stdlib + existing `PyYAML` (already a dep). Zero new runtime dependencies.
- **Additive only**: no existing function signature changes. Consumers pinned to older qor-logic keep working unchanged.
- **Swallow-log error semantics**: a broken hook must not kill the governance workflow. Authoritative path stays fail-closed; hook path fails open with a logged record.
- **Section 4 Razor compliant**: `dispatch_gate_written` composes three helpers (`_enumerate_entry_points`, `_load_config_file_hooks`, `_invoke_hook_safely`) — each well under 40 LOC.

## Files

**New**:
- `qor/scripts/gate_hooks.py` — dispatcher + `GateWrittenEvent` frozen dataclass (176 LOC).
- `qor/references/hook-contract.md` — consumer-facing contract with explicit trust-model section (94 LOC).
- `tests/test_gate_hooks_*.py` — 5 files, 7 test cases.

**Changed**:
- `qor/scripts/gate_chain.py` — `write_gate_artifact` fires `_fire_gate_written_hook` after successful write (nested try/except so hooks can never break the write).
- `CHANGELOG.md` — `[Unreleased]` entry.

## Trust model

Shell-command entries in `.qor/hooks.yaml` execute arbitrary subprocess commands. This matches the trust model of `.github/workflows/`, `.pre-commit-config.yaml`, `Makefile`, npm `preinstall` scripts, etc. — whoever committed the file is trusted. Documented explicitly in `qor/references/hook-contract.md`.

## Test plan

- [x] 7 new unit tests pass: entry-point invoke-once + cache reuse, config-file dotted-path + shell argv, swallow-log, ordering (entry-points-first-then-config), no-hooks-is-noop.
- [x] Full existing suite: 715 passing. One pre-existing unrelated failure (`test_changelog_tag_coverage` — main is behind unmerged `phase/39`/`phase/39b`).
- [x] End-to-end cross-repo integration verified from a sibling governance repository's `<consumer>-qor-hook` consumer.
- [ ] Maintainer: assign release version (plan targeted v0.29.0 but that slot is taken on `phase/39`; likely v0.31.0 once phase branches reconcile).

## Downstream consumer

Paired PR in a sibling governance repository introduces `tooling/<consumer>-qor-hook/` — a minimal consumer that registers under the new entry-point group and echoes `GateWrittenEvent` to `<root>/.qor/hooks.log`. See: https://github.com/MythologIQ-Labs-LLC/a sibling governance repository/pull/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)