### PR TITLE
docs: rename Qorlogic/QorLogic in two missed current-state docs

### DIFF
--- a/docs/MERKLE_ITERATION_GUIDE.md
+++ b/docs/MERKLE_ITERATION_GUIDE.md
@@ -8,7 +8,7 @@ Software development is inherently iterative. Features change, requirements evol
 
 ### Linear Chain (Not Branching)
 
-The QorLogic Merkle chain is **strictly linear**. Each entry builds on the previous one, regardless of iteration:
+The Qor-logic Merkle chain is **strictly linear**. Each entry builds on the previous one, regardless of iteration:
 
 ```
 GENESIS -> ENCODE -> AUDIT -> IMPLEMENT -> SEAL -> ENCODE_v2 -> AUDIT_v2 -> IMPLEMENT_v2 -> SEAL_v2

--- a/docs/SKILL_REGISTRY.md
+++ b/docs/SKILL_REGISTRY.md
@@ -1,4 +1,4 @@
-# Qorlogic Skill Registry
+# Qor-logic Skill Registry
 
 **Snapshot**: 2026-04-29
 **Authoritative location**: `qor/skills/<category>/<skill>/`


### PR DESCRIPTION
## Summary

Followup to PR #25 (`docs: rename QorLogic/Qorlogic -> Qor-logic`). The initial rename pass excluded `docs/SKILL_REGISTRY.md` and `docs/MERKLE_ITERATION_GUIDE.md` via overly-broad SKIP rules — those treated them as historical immutable, but they're current-state docs. Fixing.

- `docs/SKILL_REGISTRY.md` line 1: `# Qorlogic Skill Registry` → `# Qor-logic Skill Registry`
- `docs/MERKLE_ITERATION_GUIDE.md` line 11: "The QorLogic Merkle chain..." → "The Qor-logic Merkle chain..."

Surfaced by user feedback: "what else did you miss?"

## Governance citations

- Parent plan: `docs/plan-qor-phase48-script-discoverability-and-rename.md` (the plan that began this rename arc).
- Parent ledger entry: META_LEDGER entry #160 SESSION SEAL.
- Parent Merkle seal: `5fb66d738fd0b4d0e80d1d6e753341b4af4ee3c65ac97b7a156046ff4b614a14`.
- Predecessor PR: #25 (main rename pass, 201 files).

`change_class: hotfix`. No version bump.

## Test plan

- [x] No remaining `QorLogic`/`Qorlogic` outside immutable history (META_LEDGER, archived plans, etc.) — verified via grep.
- [x] No code changes; doc-only edits.

🤖 Authored via [Qor-logic SDLC](https://github.com/MythologIQ-Labs-LLC/Qor-logic) on [Claude Code](https://claude.com/claude-code).