### PR TITLE
hygiene: add Dependabot config for actions + pip ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+# Dependabot configuration for qor-logic.
+#
+# Manages updates to:
+#   - GitHub Actions (SHA-pinned per Phase 101; Dependabot preserves the
+#     `# vX.Y.Z` annotation comments when bumping SHAs)
+#   - Python build-time dependencies in requirements-release.txt
+#     (hash-pinned per Phase 102; Dependabot regenerates hashes)
+#
+# Dependency review workflow (Phase 102, pr-dependency-review.yml) catches
+# severity-graded vulnerabilities on these bumps; the cooling-period
+# doctrine (Phase 103, doctrine-dependency-admission.md) catches the
+# freshness vector on transitive dependency updates.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "deps(actions):"
+      include: "scope"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "deps(pip):"
+      include: "scope"


### PR DESCRIPTION
## Summary

Carry-forward from the GH #118 supply-chain hardening cluster (Phases 101-103). Adds a Dependabot configuration to manage updates for both ecosystems now under hash-pinning:

- **github-actions**: weekly checks for the 6 SHA-pinned Actions added in Phase 101 (`actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, `actions/download-artifact`, `pypa/gh-action-pypi-publish`, `actions/dependency-review-action`). Dependabot preserves the `# vX.Y.Z` annotation comments when bumping SHAs.
- **pip**: weekly checks for `requirements-release.txt` (the hash-pinned `build` lockfile added in Phase 102). Dependabot regenerates SHA-256 hashes on bumps.

Both ecosystems benefit from the orthogonal supply-chain guards added in the cluster:
- The Phase 102 `pr-dependency-review.yml` workflow runs `actions/dependency-review-action` against every Dependabot PR, failing on `high` severity.
- The Phase 103 `doctrine-dependency-admission.md` policy applies the 14-day cooling-period threshold against freshness-vector attacks; operator gates new transitive dependencies via the `dep-admit-override` label + META_LEDGER entry when within-window admission is justified.

## Changes

- `.github/dependabot.yml` (NEW, 48 lines)
  - weekly schedule Monday 06:00 UTC
  - minor+patch grouped for actions to reduce PR noise
  - 5-PR open limit per ecosystem
  - labels: `dependencies` + `github-actions` or `python`
  - commit message prefix: `deps(actions):` or `deps(pip):`

## Test plan

- [ ] After merge: Dependabot runs the first scan and opens PRs (if any updates are available)
- [ ] Each Dependabot PR triggers `pr-dependency-review.yml` workflow check
- [ ] If a PR bumps a transitive dep within the 14-day window, operator either applies `dep-admit-override` (with META_LEDGER entry) or waits for the cooling period

## Citations

- Phase 101 ledger entry #274 introduced the 6 SHA pins this config now manages
- Phase 102 ledger entry #277 introduced the hash-pinned lockfile this config now manages
- Phase 103 ledger entry #280 introduced the cooling-period doctrine that coordinates with Dependabot freshness checks

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>