### PR TITLE
chore(ci): bump GitHub Actions to Node-24-compatible majors (supersedes #124-#128)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -42,11 +42,11 @@ jobs:
   install-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -61,11 +61,11 @@ jobs:
     # SG-AdjacentState-A; structural countermeasure shipped Phase 52).
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/pr-dependency-review.yml
+++ b/.github/workflows/pr-dependency-review.yml
@@ -22,14 +22,14 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -45,7 +45,7 @@ jobs:
             echo "result=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         if: steps.docs_only.outputs.result == 'false'
         with:
           python-version: "3.12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -27,7 +27,7 @@ jobs:
             echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA} which is not reachable from origin/main. Build refused."
             exit 1
           fi
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -43,7 +43,7 @@ jobs:
           cd dist
           sha256sum *.whl *.tar.gz sbom.json > SHA256SUMS
           cat SHA256SUMS
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: release-dist
           path: dist/
@@ -58,7 +58,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -69,7 +69,7 @@ jobs:
             echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA} which is not reachable from origin/main. Publish refused."
             exit 1
           fi
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: release-dist
           path: dist/
@@ -91,10 +91,10 @@ jobs:
             "lockfile_sha256": "${LOCKFILE_SHA}",
             "artifact_sha256sums": $(jq -Rs . < dist/SHA256SUMS),
             "action_pins": {
-              "actions/checkout": "34e114876b0b11c390a56381ad16ebd13914f8d5",
-              "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
-              "actions/upload-artifact": "ea165f8d65b6e75b540449e92b4886f43607fa02",
-              "actions/download-artifact": "d3f86a106a0bac45b974a628896c90dbdf5c8093",
+              "actions/checkout": "de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+              "actions/setup-python": "a309ff8b426b58ec0e2a45f0f869d46889d02405",
+              "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+              "actions/download-artifact": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
               "pypa/gh-action-pypi-publish": "cef221092ed1bacb1cc03d23a2d87d1d172e277b"
             }
           }


### PR DESCRIPTION
## Consolidated GitHub-Actions Node-24 bumps (supersedes #124–#128)

Bumps all five actions dependabot flagged, in one atomic change, **and updates the
`release.yml` `action_pins` provenance map in lockstep** — dependabot bumps the
`uses:` SHAs but not that hardcoded map, which would otherwise leave the release
evidence bundle recording stale pins.

| Action | From | To |
|--------|------|----|
| actions/checkout | 4.3.1 | 6.0.2 |
| actions/setup-python | 5.6.0 | 6.2.0 |
| actions/upload-artifact | 4.6.2 | 7.0.1 |
| actions/download-artifact | 4.3.0 | 8.0.1 |
| actions/dependency-review-action | 4.9.0 | 5.0.0 |

### Why consolidate
- The individual dependabot PRs branch from a stale (pre-Phase-107/108) base; their red CI is from that stale base, not the bumps.
- `upload-artifact`/`download-artifact` are a producer/consumer pair (`release-dist`) and must move together.
- 4 of the 5 SHAs are mirrored in `release.yml`'s `action_pins` map; updating them per-PR would drift provenance. One branch keeps `uses:` and `action_pins` consistent.

### Motivation
Node 20 actions are deprecated; GitHub forces Node 24 on 2026-06-02. `checkout@v4`/`setup-python@v5` currently run on Node 20.

Pinned by SHA (immutable) with version comments retained. All four workflow files validate as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
