### PR TITLE
fix: restore pyproject 0.83.0 omitted from phase 116 seal (#173)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qor-logic"
-version = "0.82.0"
+version = "0.83.0"
 description = "Qor-logic S.H.I.E.L.D. governance skills for Claude Code, Kilo Code, and future AI coding hosts"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Restores pyproject version to 0.83.0. The phase-116 seal (#173) omitted staging pyproject.toml, leaving main at 0.82.0 while the v0.83.0 ledger/tag say 0.83.0. v0.83.0 is re-tagged onto this commit so release.yml builds a correctly-versioned wheel. Version line only; no code change.