### PR TITLE
seal: phase 121 - runtime-principal fidelity + Data-API access-control enforcement (v0.88.0) (#177)

### DIFF
--- a/.agent/staging/AUDIT_REPORT.md
+++ b/.agent/staging/AUDIT_REPORT.md
@@ -1,25 +1,45 @@
-# AUDIT REPORT — Phase 120 (Governance Index enforcement, GH #149)
+# AUDIT REPORT — Phase 121 (Runtime-principal fidelity + Data-API access-control, GH #177)
 
-**Target**: docs/plan-qor-phase120-governance-index-enforcement.md
+**Target**: docs/plan-qor-phase121-runtime-principal-fidelity.md
 **Verdict**: PASS
-**Risk Grade**: L2 (governance-gate surface; fail-closed enforcement + read-only cross-check; not L3)
-**Mode**: solo (Phase 87 audit_risk_score: option_b_required=false)
+**Risk Grade**: L2 (governance-gate + security surface; fail-closed static-analysis lint + prompt-contract gate; no runtime auth decision on user data; not L3)
+**Mode**: solo (audit_risk_score: option_b_required=false; no author-momentum signal)
+**Session**: 2026-06-01T2250-540aa1
+
+## Pre-audit gauntlet
+
+- plan_iteration_status_lint: exit 0 (plan is audit-ready, no draft/pre-audit markers).
+- audit_risk_score: option_b_required=false (solo permitted).
+- prompt_injection_canaries: exit 0 (no canaries in plan / META_LEDGER).
+- plan_test_lint / plan_grep_lint / plan_text_consistency_lint: exit 0.
 
 ## Passes
-- Prompt Injection: PASS (canaries exit 0)
-- Security L3: PASS. Enforcement fail-closes on genuine drift; auto-advance Last-Reviewed clears stale-tier1 by construction; disclosed-skip (Phase 75) for absent index; validate cross-check is read-only. Mutation-during-seal (advance Last-Reviewed) is established practice (changelog/version/ledger already mutate at seal); mutated file is staged.
-- OWASP: PASS (no shell; file I/O via Path; A08 no unsafe deserialization)
-- Ghost UI / Live-Progress: N/A
-- Section 4 Razor: PASS (advance/enforce/cross-check ~15-25 lines each)
-- Test Functionality: PASS (tests invoke units + assert findings/file-state/exit; wiring tests are prompt-contract reading SKILL.md)
-- Dependency: PASS (stdlib only)
-- Macro Architecture: PASS (extends governance_index.py + the governance-index CLI subparser; check_index_drift untouched -> /qor-status + Phase 112 surface preserved)
-- Feature Test Coverage: PASS (2 Feature Inventory rows, behavioral descriptors)
-- Infrastructure Alignment: PASS (grep-verified: IndexFinding, check_index_drift, _latest_seal_date, _registered_paths, _governance_docs, _last_reviewed all exist; GOVERNANCE_INDEX.md + both skills + Step Prerequisites table present; measured current drift = stale-tier1 only, zero unregistered, so fail-closed will not break the seal)
-- Filter-Stage / Orphan: N/A / PASS
 
-## Note
-tier3-unarchived heuristic (phase <N> in Tier3 -> matching SESSION SEAL -- Phase <N>): semantically sound (a sealed phase belongs in Tier6 Archived, not Tier3 Active); forward guard (Tier3 currently empty).
+- **Prompt Injection**: PASS (canaries clean).
+- **Security L3**: PASS. The plan ADDS security enforcement (RLS/grant/definer-view detection). Lint is regex over SQL files, argv-driven `main`, no `shell=True`, no secrets, no bypassed checks. Fail-closed (no fail-open); disclosed-skip is explicit and logged, not silent.
+- **OWASP Top 10**: PASS. A03 — file read + regex, list-form argv, no shell. A04 — fail-closed gate; disclosed-skip is an explicit provenance escape, not a silent drop. A05 — no secrets/temp-file perms. A08 — no pickle/eval/exec/yaml.load.
+- **Ghost UI / Live-Progress**: N/A (no UI surface).
+- **Section 4 Razor**: PASS. Module decomposes into small pure `parse_*` helpers + `analyze` (policy) + `main` (process). Each well under 40 lines; de-complected parsing/policy/exit. File estimate < 250.
+- **Self-Application Sub-Pass** (originating_remediation=GH #177): PASS. The discipline introduced is "prove behavior under the real runtime principal, not a privileged one; fail-close on missing grants." Applied to the plan itself: its own enforcement is verified by behavior — `test_main_exit_1_on_blocking` invokes `main` and asserts exit 1; `test_main_exit_0_and_skip_line_when_no_migrations` asserts the disclosed-skip. The plan does not merely declare the gate; it tests that the gate fail-closes. No self-violation.
+- **Test Functionality**: PASS. All nine behavioral tests invoke `analyze`/`main` and assert on outputs (findings, exit codes, SKIP line), including inverse cases (grant-clears, security_invoker-clears, non-API-schema-not-flagged). Wiring tests are prompt-contract: they assert load-bearing co-occurrence (`data_api_acl_lint` + `|| ABORT`; the prerequisite row; the three audit checklist items) — if the instruction were weakened (e.g., ABORT downgraded to WARN) the test fails, satisfying the SG-035 acceptance question at prompt-contract scope (same accepted pattern as Phase 120 wiring tests). `KNOWN_FINDING_KINDS` is a finding-kind constant, not a `normalize*` alias taxonomy, so the strict inverse-coverage VETO trigger does not apply; `test_doctrine_documents_finding_kinds` nonetheless supplies inverse coverage (every kind documented).
+- **Feature Test Coverage**: PASS. Both Feature Inventory Touches rows cite a `test_path` and a behavioral `test_descriptor` (flags missing-grant / returns skipped; carries the ABORT gate) — not presence-only.
+- **Dependency Audit**: PASS. Stdlib only (`re`, `pathlib`); no new third-party dependency.
+- **Macro-Level Architecture**: PASS. NEW lint lives in `qor/scripts` (correct layer); skills invoke it via the `qor-logic scripts` dispatch; doctrine in `qor/references`. No cyclic or reverse imports.
+- **Infrastructure Alignment**: PASS. `qor-logic scripts <module>` dispatch verified in `qor/cli.py` `_register_module_dispatch`; the new module is declared NEW in Affected Files. Step 4.6 ladder, Step Prerequisites table, and qor-audit Security Pass anchor points exist in current source. Phase 110 `signature-widening-exempt` escape-comment precedent exists. `runtime_contract_walk` WARNs (module not found / no caller) are expected for a NEW module and are WARN-only in V2.
+- **Filter-Stage Ordering**: PASS. `analyze` has a parse→policy shape, not a candidate-selection pipeline; escape-annotation suppression is a precondition of finding emission (no ordering inversion). Implement note (non-binding): escape-comment detection must precede finding emission — the plan's structure already implies this.
+- **Orphan Detection**: PASS. Module reachable via CLI dispatch + qor-substantiate invocation + test imports.
 
-## Next Action
-PASS -> /qor-implement
+## Advisory (non-blocking)
+
+- **Behavioral-semantics citation**: the plan's Postgres `security_invoker` claim (default views are definer-rights; `security_invoker = true` makes them invoker-rights) is correct and the lint's correctness does not depend on runtime DB behavior (it is a static text scan). Recommend the implement phase add an inline upstream citation in `doctrine-runtime-principal-fidelity.md`. Not an infrastructure-mismatch (the scanned SQL syntax is real and verifiable).
+- **ci_coverage_lint WARN**: `pr-dependency-review.yml::dependency-review` (`dependency_admission_lint`) is unenumerated in the plan's CI Commands. Pre-existing CI infrastructure, not phase-relevant (plan touches no dependencies). Eligible for a `## CI Coverage Exemptions` entry; not required for PASS.
+- **workspace_fragility**: high housekeeping signal (106 local branches; 8 dirty gate artifacts; 3073-line recent diff). Orthogonal to this plan; flagged for operator cleanup.
+
+## Process Pattern Advisory
+
+<!-- qor:veto-pattern-advisory -->
+No repeated-VETO pattern detected (this is the first audit of Phase 121; prior two sealed phases are PASS seals).
+
+## Next action
+
+PASS -> `/qor-implement`. Per qor/gates/chain.md.

--- a/.qor/gates/2026-06-01T2250-540aa1/audit.json
+++ b/.qor/gates/2026-06-01T2250-540aa1/audit.json
@@ -1,0 +1,17 @@
+{
+  "phase": "audit",
+  "session_id": "2026-06-01T2250-540aa1",
+  "ts": "2026-06-01T22:53:47Z",
+  "target": "docs/plan-qor-phase121-runtime-principal-fidelity.md",
+  "verdict": "PASS",
+  "report_path": ".agent/staging/AUDIT_REPORT.md",
+  "risk_grade": "L2",
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.87.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "pass",
+    "ts": "2026-06-01T22:53:47Z"
+  }
+}

--- a/.qor/gates/2026-06-01T2250-540aa1/audit_history.jsonl
+++ b/.qor/gates/2026-06-01T2250-540aa1/audit_history.jsonl
@@ -1,0 +1,1 @@
+{"ai_provenance":{"host":"unknown","human_oversight":"pass","model_family":"unknown","system":"Qor-logic","ts":"2026-06-01T22:53:47Z","version":"0.87.0"},"phase":"audit","report_path":".agent/staging/AUDIT_REPORT.md","risk_grade":"L2","session_id":"2026-06-01T2250-540aa1","target":"docs/plan-qor-phase121-runtime-principal-fidelity.md","ts":"2026-06-01T22:53:47Z","verdict":"PASS"}

--- a/.qor/gates/2026-06-01T2250-540aa1/implement.json
+++ b/.qor/gates/2026-06-01T2250-540aa1/implement.json
@@ -1,0 +1,22 @@
+{
+  "phase": "implement",
+  "session_id": "2026-06-01T2250-540aa1",
+  "ts": "2026-06-01T22:59:45Z",
+  "files_touched": [
+    "qor/scripts/data_api_acl_lint.py",
+    "tests/test_data_api_acl_lint.py",
+    "tests/test_runtime_principal_wiring.py",
+    "qor/skills/governance/qor-substantiate/SKILL.md",
+    "qor/skills/governance/qor-audit/SKILL.md",
+    "qor/references/doctrine-runtime-principal-fidelity.md",
+    "qor/references/glossary.md"
+  ],
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.87.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "absent",
+    "ts": "2026-06-01T22:59:45Z"
+  }
+}

--- a/.qor/gates/2026-06-01T2250-540aa1/plan.json
+++ b/.qor/gates/2026-06-01T2250-540aa1/plan.json
@@ -1,0 +1,36 @@
+{
+  "phase": "plan",
+  "session_id": "2026-06-01T2250-540aa1",
+  "ts": "2026-06-01T22:50:19Z",
+  "plan_path": "docs/plan-qor-phase121-runtime-principal-fidelity.md",
+  "phases": [
+    "Phase 1: Data-API access-control lint (qor/scripts/data_api_acl_lint.py)",
+    "Phase 2: Skill wiring + variant recompile",
+    "Phase 3: Doctrine + reference + glossary"
+  ],
+  "ci_commands": [
+    "python -m pytest tests/test_data_api_acl_lint.py tests/test_runtime_principal_wiring.py -q",
+    "python -m qor.cli scripts data_api_acl_lint --repo-root .",
+    "python -m pytest -q"
+  ],
+  "doc_tier": "standard",
+  "terms": [
+    {
+      "term": "runtime-principal fidelity",
+      "home": "qor/references/doctrine-runtime-principal-fidelity.md"
+    },
+    {
+      "term": "Data-API access-control lint",
+      "home": "qor/references/doctrine-runtime-principal-fidelity.md"
+    }
+  ],
+  "originating_remediation": "GH #177",
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.87.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "absent",
+    "ts": "2026-06-01T22:50:19Z"
+  }
+}

--- a/.qor/gates/2026-06-01T2250-540aa1/substantiate.json
+++ b/.qor/gates/2026-06-01T2250-540aa1/substantiate.json
@@ -1,0 +1,17 @@
+{
+  "phase": "substantiate",
+  "session_id": "2026-06-01T2250-540aa1",
+  "ts": "2026-06-01T23:14:38Z",
+  "verdict": "PASS",
+  "merkle_seal": "ac720e6a355c71cd4e45dca5071beddd600827e3cf58199ebd6345ff56ee08cc",
+  "content_hash": "4ad2328866c7905edd407142100033493b2ea8feceab98d8545417f40aafc4cb",
+  "ledger_entry": 314,
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.88.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "pass",
+    "ts": "2026-06-01T23:14:38Z"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ file is the user-facing narrative.
 
 ## [Unreleased]
 
+## [0.88.0] - 2026-06-01
+
+### Added
+- **Phase 121 (#177)**: Runtime-principal fidelity + Data-API access-control enforcement. Closes the privileged-principal false-PASS class where tests run under `service_role` / a `SECURITY DEFINER` RPC bypass RLS + table `GRANT`s, so a feature broken for its `authenticated`/`anon` caller seals green. `/qor-substantiate` Step 4 adds a runtime-principal fidelity gate (fail-closed unless an explicit disclosed coverage-gap note is recorded) and Step 4.6.10 invokes the new `qor.scripts.data_api_acl_lint` (`|| ABORT`): a static SQL-migration scan flagging `missing-grant` (API-schema `CREATE TABLE` with no GRANT to authenticated/anon) and `definer-view` (view without `security_invoker = true`); `security-definer-fn` is advisory. Escapes: `-- qor:service-role-only`, `-- qor:definer-view-intended`. Absent migrations → Phase 75 disclosed-skip. `/qor-audit` Security Pass gains the plan-level Data-API access-control checklist.
+
 ## [0.87.0] - 2026-05-30
 
 _Built via [Qor-logic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)._

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
   <a href="https://pypi.org/project/qor-logic/"><img src="https://img.shields.io/pypi/v/qor-logic?color=blue&label=PyPI" alt="PyPI"></a>
   <img src="https://img.shields.io/badge/Python-3.11%2B-blue" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/License-BSL--1.1-orange" alt="License: BSL-1.1">
-  <img src="https://img.shields.io/badge/Tests-2115%20passing-brightgreen" alt="Tests: 2115 passing">
+  <img src="https://img.shields.io/badge/Tests-2130%20passing-brightgreen" alt="Tests: 2130 passing">
   <img src="https://img.shields.io/badge/NIST-SP%20800--218A%20%2B%20AI%20RMF%201.0-004488" alt="NIST SP 800-218A + AI RMF 1.0">
   <img src="https://img.shields.io/badge/OWASP-Top%2010%20%2B%20LLM%20Top%2010-004488" alt="OWASP Top 10 + LLM Top 10">
   <img src="https://img.shields.io/badge/EU%20AI%20Act-aligned-004488" alt="EU AI Act aligned">
   <img src="https://img.shields.io/badge/Skills-30-blue" alt="Skills: 30">
   <img src="https://img.shields.io/badge/Agents-13-blue" alt="Agents: 13">
-  <img src="https://img.shields.io/badge/Doctrines-32-blue" alt="Doctrines: 32">
-  <img src="https://img.shields.io/badge/Ledger-313%20entries%20sealed-green" alt="Ledger: 313 entries sealed">
+  <img src="https://img.shields.io/badge/Doctrines-33-blue" alt="Doctrines: 33">
+  <img src="https://img.shields.io/badge/Ledger-314%20entries%20sealed-green" alt="Ledger: 314 entries sealed">
   <img src="https://img.shields.io/badge/Doc%20Tier-system-green" alt="Doc Tier: system">
 </p>
 

--- a/docs/GOVERNANCE_INDEX.md
+++ b/docs/GOVERNANCE_INDEX.md
@@ -1,6 +1,6 @@
 # Governance Index
 
-**Last Reviewed**: 2026-05-30
+**Last Reviewed**: 2026-06-01
 
 A single authoritative map of every governance artifact in Qor-logic, organized
 into six freshness tiers with explicit drift contracts. A stale entry here is

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -11515,7 +11515,28 @@ Change class: feature. Tests: 2115 passed / 0 failed / 3 skipped (full suite). A
 **Previous Hash**: `7e87318074a0bf4b41f6b01a66d3b03cd8c2dc5fdd32ff807c297b89caddb3d2`
 **Chain Hash (Merkle seal)**: `423653f67ca485f493706da18d7203c5cea0599e00f23519b2e3e080a4f3aead`
 
+### Entry #314: SESSION SEAL -- Phase 121 runtime-principal fidelity + Data-API access-control (v0.88.0)
+
+**Timestamp**: 2026-06-01T23:14:03Z
+**Phase**: SUBSTANTIATE (Phase 121; feature)
+**Author**: Judge
+**Change class**: feature
+**Plan**: docs/plan-qor-phase121-runtime-principal-fidelity.md
+**Session**: `2026-06-01T2250-540aa1`
+**SSDF Practices**: PO.1.3, PO.1.4, PS.2.1, PS.3.2, PW.1.1, PW.4.1, PW.5.1, PW.9.1
+**Entry ID**: `4a0923984fbd`
+
+**Scope**: Phase 121 implemented (#177): Runtime-principal fidelity + Data-API access-control enforcement. Closes the privileged-principal false-PASS class -- tests run under service_role / a SECURITY DEFINER RPC bypass RLS + table GRANTs, so a feature broken for its authenticated/anon caller seals green. /qor-substantiate Step 4 adds a runtime-principal fidelity gate (fail-closed unless an explicit disclosed coverage-gap note is recorded) and Step 4.6.10 invokes the new qor.scripts.data_api_acl_lint (|| ABORT): static SQL-migration scan flagging missing-grant (API-schema CREATE TABLE with no GRANT to authenticated/anon) and definer-view (view without security_invoker = true); security-definer-fn advisory. Escapes -- qor:service-role-only / -- qor:definer-view-intended; absent migrations -> Phase 75 disclosed-skip. /qor-audit Security Pass gains the plan-level Data-API access-control checklist. New reference doctrine-runtime-principal-fidelity.md + 2 glossary terms. 15 new behavioral+wiring tests. Also fixed phase-120 seal commit trailer (b4ec643->9c37435 canonical Authored-via trailer) and README Tests/Doctrines badges.
+
+Change class: feature. Tests: 2127 passed / 0 failed / 3 skipped (full suite). Audit PASS (L2 solo).
+
+**Review Boundary**: Operator authorized push + PR post-seal (GH #177).
+
+**Content Hash**: `4ad2328866c7905edd407142100033493b2ea8feceab98d8545417f40aafc4cb`
+**Previous Hash**: `423653f67ca485f493706da18d7203c5cea0599e00f23519b2e3e080a4f3aead`
+**Chain Hash (Merkle seal)**: `ac720e6a355c71cd4e45dca5071beddd600827e3cf58199ebd6345ff56ee08cc`
+
 ---
 
 *Chain integrity: VALID*
-*Session: SEALED* (Phase 120; v0.87.0 local, held for operator review)
+*Session: SEALED* (Phase 121; v0.88.0 local; operator authorized push + PR)

--- a/docs/plan-qor-phase121-runtime-principal-fidelity.md
+++ b/docs/plan-qor-phase121-runtime-principal-fidelity.md
@@ -1,0 +1,161 @@
+# Plan: Runtime-principal fidelity + Data-API access-control enforcement
+
+**change_class**: feature
+
+**doc_tier**: standard
+
+**terms_introduced**:
+- term: runtime-principal fidelity
+  home: qor/references/doctrine-runtime-principal-fidelity.md
+- term: Data-API access-control lint
+  home: qor/references/doctrine-runtime-principal-fidelity.md
+
+**boundaries**:
+- limitations: The grant/view lint is a static SQL scan (regex over migration files), not a live database probe. It detects the deterministic high-confidence cases (a `CREATE TABLE` in an API-exposed schema with no `GRANT` to a non-owner runtime role and no service-role-only marker; a view created without `security_invoker = true`). It does not execute SQL, resolve cross-file ALTER/GRANT ordering beyond the scanned migration set, or prove a view's base tables actually carry RLS. The runtime-principal fidelity check (#177-A) is a prompt-contract acceptance gate (operator judgment, like the existing presence-only seal gate), not an executable detector of "this test used a service-role client."
+- non_goals: A test-fidelity lint that statically flags service-role/privileged client construction in target tests (the heuristic Full-option, deferred — false-positive risk like #174). Live-database RLS probing. Auto-fixing missing grants. Non-Postgres access-control models (MySQL grants, Mongo rules).
+- exclusions: Repos with no SQL migration directory (the lint records a Phase 75 disclosed-skip). Features with no DB read/write reachable by a non-privileged caller (the runtime-principal gate is satisfied vacuously).
+
+## Open Questions
+
+None blocking. One resolved design note recorded for the auditor:
+
+- **Where the executable lint lives.** GH #177 frames the grant/view checklist under `qor-audit` (remediation B). But `qor-audit` reviews the **plan/blueprint pre-implementation**, when the SQL migrations do not yet exist; the implemented SQL exists at **seal time**. The deterministic lint therefore runs as a fail-closed gate in **`qor-substantiate`** (over real migrations), while `qor-audit` receives the **plan-level checklist items** (prompt-contract: the auditor confirms the plan commits to grants for any API-exposed table it introduces and flags any definer-rights view/SECURITY DEFINER design). This splits #177-B across both skills at the artifact boundary each one actually sees. De-complecting: detection of implemented reality (substantiate, deterministic) is separated from review of declared intent (audit, judgment).
+
+## Context
+
+GH #177 (filed from an Accountable customer-app autonomous cycle; two independent false-PASS instances). Root cause: the verifying principal (`service_role` key, or a `SECURITY DEFINER` RPC running as table owner) has more privilege than the runtime caller (`authenticated`/`anon`), so TDD-Light/integration tests exercise a path that does not exist for real users. `qor-substantiate` returns PASS on code that `42501`s in production. The current skills have no runtime-principal fidelity requirement and no Data-API grant/view check; this phase ships both, fail-closed with disclosed-skip per the operator decision.
+
+## Feature Inventory Touches
+
+(`docs/FEATURE_INDEX.md` absent; declared for traceability. Plan touches `qor/` package + skills + tests, not `src/`.)
+
+- entry_id: `n/a` · operation: `NEW` · test_path: `tests/test_data_api_acl_lint.py` · test_descriptor: `data_api_acl_lint.analyze flags a public CREATE TABLE with no GRANT to authenticated/anon (missing-grant) and a non-security_invoker view (definer-view); returns skipped when no migrations exist`
+- entry_id: `n/a` · operation: `NEW` · test_path: `tests/test_runtime_principal_wiring.py` · test_descriptor: `qor-substantiate SKILL.md carries the runtime-principal fidelity ABORT gate + data_api_acl_lint || ABORT invocation; qor-audit SKILL.md carries the Data-API access-control checklist items`
+
+## Phase 1: Data-API access-control lint (`qor/scripts/data_api_acl_lint.py`)
+
+### Affected Files
+
+- `tests/test_data_api_acl_lint.py` - NEW. Behavioral tests over synthetic SQL (see Unit Tests). Written first; red before the module exists.
+- `qor/scripts/data_api_acl_lint.py` - NEW. Static SQL scanner + `main(argv)` entrypoint dispatchable via `qor-logic scripts data_api_acl_lint` (Phase 118 module dispatch; no dedicated subparser).
+
+### Changes
+
+```python
+# Finding kinds: "missing-grant" (blocking), "definer-view" (blocking),
+# "security-definer-fn" (advisory), "missing-migrations" (disclosed-skip sentinel).
+@dataclass(frozen=True)
+class AclFinding:
+    kind: str
+    object_name: str   # schema-qualified table/view/function
+    file: str          # migration path
+    detail: str
+
+@dataclass(frozen=True)
+class AclResult:
+    findings: tuple[AclFinding, ...]
+    skipped: bool      # True when no SQL migrations were found (Phase 75)
+    skip_reason: str
+
+DEFAULT_API_SCHEMAS = ("public",)
+MIGRATION_GLOBS = ("supabase/migrations/*.sql", "migrations/*.sql",
+                   "db/migrations/*.sql", "db/**/*.sql")
+
+def find_sql_migrations(base: Path) -> list[Path]: ...
+def parse_created_tables(sql: str) -> list[tuple[str, str]]: ...   # (schema, name)
+def parse_grants(sql: str) -> list[tuple[str, str]]: ...           # (object, role)
+def parse_revokes(sql: str) -> list[tuple[str, str]]: ...          # (object, role)
+def parse_views(sql: str) -> list[tuple[str, bool]]: ...           # (name, security_invoker_on)
+def parse_definer_functions(sql: str) -> list[str]: ...
+
+def analyze(base: Path, api_schemas=DEFAULT_API_SCHEMAS) -> AclResult:
+    """Scan all migrations as one corpus. Flag:
+      missing-grant   -- a table in an API schema with no GRANT to a non-owner
+                         runtime role (authenticated/anon), no REVOKE marking it
+                         service-role-only, and no `-- qor:service-role-only`
+                         escape comment.
+      definer-view    -- a view in an API schema created without
+                         `security_invoker = true`, no `-- qor:definer-view-intended`
+                         escape comment.
+      security-definer-fn -- advisory: each SECURITY DEFINER function (reviewed,
+                         not blocked).
+    Returns skipped=True when no migration files exist (disclosed-skip)."""
+
+def main(argv: list[str] | None = None) -> int:
+    """--repo-root PATH [--api-schemas a,b]. Exit 1 on any BLOCKING finding
+    (missing-grant/definer-view) lacking an escape annotation; exit 0 when clean
+    OR skipped (prints a `SKIP:` line so the caller records the Phase 75 event).
+    Advisory findings print but do not change a clean exit 0."""
+```
+
+Escape annotations mirror the established inline-comment exemption pattern (Phase 110 `signature-widening-exempt`): a `-- qor:service-role-only` comment on or immediately above a `CREATE TABLE` suppresses `missing-grant` (the issue's instance 1 was a *legitimately* service-role-only table; the lint must not flag intentional ones); `-- qor:definer-view-intended reason: <text>` suppresses `definer-view`. De-complecting: parsing (the `parse_*` helpers, each a pure `str -> list`) is separated from policy (`analyze`), which is separated from process exit (`main`).
+
+### Unit Tests
+
+- `tests/test_data_api_acl_lint.py::test_missing_grant_flagged` - migration with `CREATE TABLE public.items (...)` and no GRANT; `analyze` returns one `missing-grant` finding naming `public.items`.
+- `::test_grant_to_authenticated_clears` - same table plus `GRANT SELECT ON public.items TO authenticated`; `analyze` returns no `missing-grant`.
+- `::test_service_role_only_escape_clears` - table preceded by `-- qor:service-role-only` and `REVOKE ALL ON public.items FROM authenticated`; no `missing-grant` (intentional, not flagged).
+- `::test_definer_view_flagged` - `CREATE VIEW public.v AS SELECT ...` with no `security_invoker`; returns a `definer-view` finding.
+- `::test_security_invoker_view_clears` - `CREATE VIEW public.v WITH (security_invoker = true) AS ...`; no `definer-view` finding.
+- `::test_security_definer_fn_is_advisory` - a `SECURITY DEFINER` function yields a `security-definer-fn` finding AND `main` still exits 0 when that is the only finding (advisory, non-blocking).
+- `::test_main_exit_1_on_blocking` - repo dir with a `missing-grant`; `main(["--repo-root", str(d)])` returns 1.
+- `::test_main_exit_0_and_skip_line_when_no_migrations` - empty repo; `main` returns 0 and stdout contains `SKIP:` (disclosed-skip sentinel).
+- `::test_non_api_schema_table_not_flagged` - `CREATE TABLE internal.audit_log (...)` with `api_schemas=("public",)`; no finding (only API-exposed schemas are in scope).
+
+## Phase 2: Skill wiring + variant recompile
+
+### Affected Files
+
+- `tests/test_runtime_principal_wiring.py` - NEW. Prompt-contract assertions on both SKILL.md files (see Unit Tests).
+- `qor/skills/governance/qor-substantiate/SKILL.md` - add (a) a Step 4 sub-section "Runtime-Principal Fidelity gate" (prompt-contract ABORT with disclosed coverage-gap escape), and (b) Step 4.6.10 invoking `qor-logic scripts data_api_acl_lint --repo-root . || ABORT`, plus a `module:qor.scripts.data_api_acl_lint` row in the Step Prerequisites table. Detailed prose lives in the reference (progressive disclosure); SKILL.md carries the short step + invocation only.
+- `qor/skills/governance/qor-audit/SKILL.md` - extend the Security Pass checklist (Step 3) with the three Data-API access-control items (plan-level, prompt-contract VETO).
+- `qor/dist/variants/**` - regenerated via `qor-logic compile`.
+
+### Changes
+
+`qor-substantiate` Step 4 gains, after the presence-only seal gate, a short Runtime-Principal Fidelity gate: for any feature whose acceptance includes a DB read/write reachable by a non-privileged caller (authenticated/anon), the operator confirms at least one test exercises that path under the real caller role. If the path is proven only under `service_role` / a `SECURITY DEFINER` RPC, the seal ABORTs UNLESS the operator records an explicit coverage-gap note in the seal entry ("data path verified only under service_role; authenticated/RLS path deferred to manual QA") and emits a `gate_skipped_prerequisite_absent`-style shadow event. The detailed acceptance question + examples live in `qor/references/doctrine-runtime-principal-fidelity.md`.
+
+Step 4.6.10 adds the deterministic lint to the fail-closed reliability ladder using the established `|| ABORT` idiom (matching Step 4.6.5 secret-scanner and Step 4.7.5 governance-index). Phase 75 disclosed-skip applies when no migrations exist (the `SKIP:` line maps to the recorded skip event).
+
+`qor-audit` Security Pass gains three checklist items (plan-level review): (1) every API-exposed `CREATE TABLE` the plan introduces commits to explicit GRANTs; (2) `SECURITY DEFINER` functions and definer-rights (non-`security_invoker`) views over RLS-bearing tables are called out and access-scoped; (3) a plan whose runtime caller is authenticated but whose tests construct a privileged (service-role) client is insufficient proof. Any violation -> VETO.
+
+### Unit Tests
+
+- `tests/test_runtime_principal_wiring.py::test_substantiate_has_runtime_principal_gate` - read `qor-substantiate/SKILL.md`; assert it contains the runtime-principal fidelity gate with an ABORT directive AND the disclosed coverage-gap escape phrase, co-located within one section. Prompt-contract test.
+- `::test_substantiate_invokes_data_api_acl_lint` - assert SKILL.md contains `data_api_acl_lint` followed by `|| ABORT` within a short window (fail-closed, not WARN).
+- `::test_substantiate_has_acl_prerequisite_row` - assert the Step Prerequisites table has a `module:qor.scripts.data_api_acl_lint` row (Phase 75 disclosed-skip declared).
+- `::test_audit_security_pass_has_dataapi_items` - read `qor-audit/SKILL.md`; assert the Security Pass region contains all three Data-API access-control checklist items (grant-on-API-table, definer-view/SECURITY-DEFINER flag, service-role-test-insufficiency).
+
+## Phase 3: Doctrine + reference + glossary
+
+### Affected Files
+
+- `qor/references/doctrine-runtime-principal-fidelity.md` - NEW. Home for both introduced terms; carries the detailed runtime-principal acceptance question, the privileged-vs-runtime-principal root cause, the lint finding-kind table + escape annotations, and the substantiate/audit split rationale (progressive-disclosure target for the two SKILL.md steps).
+- `qor/references/glossary.md` - add `runtime-principal fidelity` and `Data-API access-control lint` entries.
+- `tests/test_data_api_acl_lint.py::test_doctrine_documents_finding_kinds` - functional doc-contract: the reference names every finding kind the module emits.
+
+### Changes
+
+The reference doc states the contract the two skills point at; the glossary cross-links it. The doc-contract test reads `analyze`'s emitted kinds reflectively (or a `KNOWN_FINDING_KINDS` constant in the module) and asserts each appears in the reference — so the doc cannot drift from the code (inverse-coverage discipline per `doctrine-test-functionality.md`).
+
+## Definition of Done
+
+### Deliverable: Data-API access-control lint
+
+- **D1**: a static SQL scan makes `missing-grant` and non-`security_invoker` `definer-view` defects fail-close the seal; service-role-only tables and intended definer views are not flagged (escape annotations).
+- **D2**: `qor/scripts/data_api_acl_lint.py` with `analyze`, the `parse_*` helpers, `KNOWN_FINDING_KINDS`, and `main(argv)`; dispatchable as `qor-logic scripts data_api_acl_lint`.
+- **D3**: Step 4.6.10 invocation + Step Prerequisites row in qor-substantiate SKILL.md; reference doc + glossary entries; META_LEDGER seal entry; version bump.
+- **D4**: `tests/test_data_api_acl_lint.py::test_missing_grant_flagged` + `::test_definer_view_flagged` + `::test_service_role_only_escape_clears` + `::test_main_exit_0_and_skip_line_when_no_migrations`.
+
+### Deliverable: runtime-principal fidelity + audit checklist
+
+- **D1**: /qor-substantiate fail-closes on service-role-only proof of an authenticated path (unless a disclosed coverage-gap note is recorded); /qor-audit reviews API-table grants + definer views at plan time.
+- **D2**: Step 4 Runtime-Principal Fidelity gate in qor-substantiate SKILL.md; three Data-API items in qor-audit Security Pass; variants recompiled.
+- **D3**: Phase 75 disclosed-skip declared for absent migrations; coverage-gap disclosed-skip declared for the runtime-principal gate.
+- **D4**: `tests/test_runtime_principal_wiring.py::test_substantiate_has_runtime_principal_gate` + `::test_substantiate_invokes_data_api_acl_lint` + `::test_audit_security_pass_has_dataapi_items`.
+
+## CI Commands
+
+- `python -m pytest tests/test_data_api_acl_lint.py tests/test_runtime_principal_wiring.py -q` — new lint + wiring.
+- `python -m qor.cli scripts data_api_acl_lint --repo-root .` — canonical repo records a Phase 75 disclosed-skip (no SQL migrations) and exits 0.
+- `python -m pytest -q` — full suite green before substantiate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qor-logic"
-version = "0.87.0"
+version = "0.88.0"
 description = "Qor-logic S.H.I.E.L.D. governance skills for Claude Code, Kilo Code, and future AI coding hosts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/qor/dist/manifest.json
+++ b/qor/dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-05-30T07:07:40Z",
+  "generated_ts": "2026-06-01T23:14:38Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "c9d9e4949c7f7299e27998c18cdb83aacaca031689193582d3f537f04f402700"
+      "sha256": "b18c6c9e63e1590d44e33fa4cd11d05e96b702663bb14c3fd2387081adfb11db"
     },
     {
       "id": "qor-bootstrap",
@@ -390,7 +390,7 @@
       "id": "qor-substantiate",
       "source_path": "skills/qor-substantiate/SKILL.md",
       "install_rel_path": "skills/qor-substantiate/SKILL.md",
-      "sha256": "aff3e0b33d2a9d90f52ea77ccaf832c983655633e25b6cb8e2a61e2fe2275f2b"
+      "sha256": "50de4d4d2ae323ec7ff0ac197e0f49e36fcf5c3a79ba13b014d2aa1dd464fbc2"
     },
     {
       "id": "qor-tone",

--- a/qor/dist/variants/claude/manifest.json
+++ b/qor/dist/variants/claude/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-05-30T07:07:40Z",
+  "generated_ts": "2026-06-01T23:14:37Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "c9d9e4949c7f7299e27998c18cdb83aacaca031689193582d3f537f04f402700"
+      "sha256": "b18c6c9e63e1590d44e33fa4cd11d05e96b702663bb14c3fd2387081adfb11db"
     },
     {
       "id": "qor-bootstrap",
@@ -390,7 +390,7 @@
       "id": "qor-substantiate",
       "source_path": "skills/qor-substantiate/SKILL.md",
       "install_rel_path": "skills/qor-substantiate/SKILL.md",
-      "sha256": "aff3e0b33d2a9d90f52ea77ccaf832c983655633e25b6cb8e2a61e2fe2275f2b"
+      "sha256": "50de4d4d2ae323ec7ff0ac197e0f49e36fcf5c3a79ba13b014d2aa1dd464fbc2"
     },
     {
       "id": "qor-tone",

--- a/qor/dist/variants/claude/skills/qor-audit/SKILL.md
+++ b/qor/dist/variants/claude/skills/qor-audit/SKILL.md
@@ -268,6 +268,14 @@ Scan for critical security issues:
 - [ ] No `// security: disabled for testing`
 ```
 
+**Data-API access-control checklist (Phase 121 wiring; GH #177)** — plan-level review of any DB surface the plan introduces (the deterministic SQL scan runs at `/qor-substantiate` Step 4.6.10, where migrations exist; here the Judge reviews declared intent):
+
+- [ ] Every API-exposed `CREATE TABLE` the plan introduces commits to explicit `GRANT`s to its runtime roles (platform defaults are not assumable and have changed)
+- [ ] `SECURITY DEFINER` functions and definer-rights (non-`security_invoker`) views over RLS-bearing tables are flagged and access-scoped (a definer-rights view bypasses base-table RLS for any reader)
+- [ ] A feature whose runtime caller is authenticated/anon but whose tests construct a privileged (service-role) client is insufficient proof of the access path
+
+Per `qor/references/doctrine-runtime-principal-fidelity.md`.
+
 **Any violation -> VETO with L3 flag**
 
 **Required next action:** `/qor-debug` (treat as code-logic defect per `qor/references/doctrine-audit-report-language.md`). If the violation is a plan-text gap rather than a runtime defect, the directive becomes: Governor: amend plan text, re-run `/qor-audit`.

--- a/qor/dist/variants/claude/skills/qor-substantiate/SKILL.md
+++ b/qor/dist/variants/claude/skills/qor-substantiate/SKILL.md
@@ -67,6 +67,7 @@ This skill is multi-step; each step declares its prerequisite so non-Python host
 | 4.6.5 secret_scanner | module:qor.scripts.secret_scanner | OWASP LLM06 / NIST AI 600-1 §2.10 |
 | 4.6.6 procedural_fidelity | module:qor.scripts.procedural_fidelity | WARN-only doc-surface coverage gap |
 | 4.7 doc_integrity (strict) | module:qor.scripts.doc_integrity | tier-driven glossary + orphan + term-drift checks |
+| 4.6.10 data_api_acl_lint | module:qor.scripts.data_api_acl_lint | Phase 121 fail-closed Data-API grant/definer-view scan (#177); absent migrations -> disclosed-skip |
 | 4.7.5 governance_index enforce | module:qor.scripts.governance_index | Phase 120 fail-closed index enforcement (advance Last-Reviewed + unregistered/tier3-unarchived) |
 | 6.5 doc currency + badge currency | module:qor.scripts.doc_integrity_strict | release-class badge ABORT (Phase 49) |
 | 6.8 seal hash integrity gate | module:qor.scripts.hash_guard | Phase 64 fail-closed gate |
@@ -192,6 +193,8 @@ Read: Test files
 Template: `references/qor-substantiate-templates.md`.
 
 **Presence-only seal gate**: substantiation refuses to seal if any test added in the current phase is presence-only for the unit it claims to verify. Operator runs the acceptance question — "If the unit's behavior were silently broken but the artifact still existed, would this test fail?" — against each new test in the phase. Any "no" answer ABORTs seal. The operator amends the test to invoke the unit and assert against its output, then re-runs `/qor-substantiate`. Per `qor/references/doctrine-test-functionality.md` and SG-035 ("doctrine-content test unanchored").
+
+**Runtime-principal fidelity gate (Phase 121 wiring; GH #177)**: for any feature whose acceptance includes a DB read/write reachable by a non-privileged caller (authenticated/anon), confirm at least one test exercises that path under the real caller role. If the path is proven only under `service_role` or a `SECURITY DEFINER` RPC (which bypass RLS + table GRANTs), ABORT the seal — UNLESS the operator records an explicit coverage-gap note in the seal entry ("data path verified only under service_role; authenticated/RLS path deferred to manual QA") and emits a `gate_skipped_prerequisite_absent` shadow event. A service-role-only proof must not silently satisfy an authenticated path. Per `qor/references/doctrine-runtime-principal-fidelity.md`.
 
 #### Visual Silence Verification (if frontend)
 ```
@@ -342,6 +345,18 @@ qor-logic scripts skill_size_budget_lint --skills-root qor/skills || true
 ```
 
 WARN-only V1: the lint emits one finding per oversized SKILL.md but does not abort substantiate. CLI exits 1 when any EXCEEDED finding (>= 40 KB) is present so V2 can convert to a hard ABORT by removing the `|| true` wrap. Operator-actionable: skills exceeding the WARN threshold should be candidates for progressive-disclosure refactor (move sub-pass / step prose to `references/` files); skills exceeding EXCEEDED should be considered overdue for refactor.
+
+### Step 4.6.10: Data-API access-control lint (Phase 121 wiring; GH #177)
+
+**Prerequisite (Phase 75; GH #38)**: requires `module:qor.scripts.data_api_acl_lint`. See Step Prerequisites table; on hosts/repos with no SQL migrations the lint prints a `SKIP:` line and exits 0 (disclosed-skip — record SKIP in the seal entry and emit a `gate_skipped_prerequisite_absent` shadow event).
+
+Static scan over the target repo's SQL migrations. Fail-closed on blocking findings (`missing-grant` — an API-schema `CREATE TABLE` with no `GRANT` to authenticated/anon and no service-role-only marker; `definer-view` — a view without `security_invoker = true`). `security-definer-fn` is advisory. Closes the privileged-principal false-PASS surface from GH #177 (a feature broken for its authenticated caller sealing green because tests ran under `service_role`).
+
+```bash
+qor-logic scripts data_api_acl_lint --repo-root . || ABORT
+```
+
+Escapes: `-- qor:service-role-only` (intentional service-role-only table) and `-- qor:definer-view-intended reason: ...` (intentional definer view). Full contract: `qor/references/doctrine-runtime-principal-fidelity.md`.
 
 ### Step 4.7: Documentation Integrity Check (Phase 28 wiring)
 

--- a/qor/dist/variants/codex/manifest.json
+++ b/qor/dist/variants/codex/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-05-30T07:07:40Z",
+  "generated_ts": "2026-06-01T23:14:38Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "c9d9e4949c7f7299e27998c18cdb83aacaca031689193582d3f537f04f402700"
+      "sha256": "b18c6c9e63e1590d44e33fa4cd11d05e96b702663bb14c3fd2387081adfb11db"
     },
     {
       "id": "qor-bootstrap",
@@ -390,7 +390,7 @@
       "id": "qor-substantiate",
       "source_path": "skills/qor-substantiate/SKILL.md",
       "install_rel_path": "skills/qor-substantiate/SKILL.md",
-      "sha256": "aff3e0b33d2a9d90f52ea77ccaf832c983655633e25b6cb8e2a61e2fe2275f2b"
+      "sha256": "50de4d4d2ae323ec7ff0ac197e0f49e36fcf5c3a79ba13b014d2aa1dd464fbc2"
     },
     {
       "id": "qor-tone",

--- a/qor/dist/variants/codex/skills/qor-audit/SKILL.md
+++ b/qor/dist/variants/codex/skills/qor-audit/SKILL.md
@@ -268,6 +268,14 @@ Scan for critical security issues:
 - [ ] No `// security: disabled for testing`
 ```
 
+**Data-API access-control checklist (Phase 121 wiring; GH #177)** — plan-level review of any DB surface the plan introduces (the deterministic SQL scan runs at `/qor-substantiate` Step 4.6.10, where migrations exist; here the Judge reviews declared intent):
+
+- [ ] Every API-exposed `CREATE TABLE` the plan introduces commits to explicit `GRANT`s to its runtime roles (platform defaults are not assumable and have changed)
+- [ ] `SECURITY DEFINER` functions and definer-rights (non-`security_invoker`) views over RLS-bearing tables are flagged and access-scoped (a definer-rights view bypasses base-table RLS for any reader)
+- [ ] A feature whose runtime caller is authenticated/anon but whose tests construct a privileged (service-role) client is insufficient proof of the access path
+
+Per `qor/references/doctrine-runtime-principal-fidelity.md`.
+
 **Any violation -> VETO with L3 flag**
 
 **Required next action:** `/qor-debug` (treat as code-logic defect per `qor/references/doctrine-audit-report-language.md`). If the violation is a plan-text gap rather than a runtime defect, the directive becomes: Governor: amend plan text, re-run `/qor-audit`.

--- a/qor/dist/variants/codex/skills/qor-substantiate/SKILL.md
+++ b/qor/dist/variants/codex/skills/qor-substantiate/SKILL.md
@@ -67,6 +67,7 @@ This skill is multi-step; each step declares its prerequisite so non-Python host
 | 4.6.5 secret_scanner | module:qor.scripts.secret_scanner | OWASP LLM06 / NIST AI 600-1 §2.10 |
 | 4.6.6 procedural_fidelity | module:qor.scripts.procedural_fidelity | WARN-only doc-surface coverage gap |
 | 4.7 doc_integrity (strict) | module:qor.scripts.doc_integrity | tier-driven glossary + orphan + term-drift checks |
+| 4.6.10 data_api_acl_lint | module:qor.scripts.data_api_acl_lint | Phase 121 fail-closed Data-API grant/definer-view scan (#177); absent migrations -> disclosed-skip |
 | 4.7.5 governance_index enforce | module:qor.scripts.governance_index | Phase 120 fail-closed index enforcement (advance Last-Reviewed + unregistered/tier3-unarchived) |
 | 6.5 doc currency + badge currency | module:qor.scripts.doc_integrity_strict | release-class badge ABORT (Phase 49) |
 | 6.8 seal hash integrity gate | module:qor.scripts.hash_guard | Phase 64 fail-closed gate |
@@ -192,6 +193,8 @@ Read: Test files
 Template: `references/qor-substantiate-templates.md`.
 
 **Presence-only seal gate**: substantiation refuses to seal if any test added in the current phase is presence-only for the unit it claims to verify. Operator runs the acceptance question — "If the unit's behavior were silently broken but the artifact still existed, would this test fail?" — against each new test in the phase. Any "no" answer ABORTs seal. The operator amends the test to invoke the unit and assert against its output, then re-runs `/qor-substantiate`. Per `qor/references/doctrine-test-functionality.md` and SG-035 ("doctrine-content test unanchored").
+
+**Runtime-principal fidelity gate (Phase 121 wiring; GH #177)**: for any feature whose acceptance includes a DB read/write reachable by a non-privileged caller (authenticated/anon), confirm at least one test exercises that path under the real caller role. If the path is proven only under `service_role` or a `SECURITY DEFINER` RPC (which bypass RLS + table GRANTs), ABORT the seal — UNLESS the operator records an explicit coverage-gap note in the seal entry ("data path verified only under service_role; authenticated/RLS path deferred to manual QA") and emits a `gate_skipped_prerequisite_absent` shadow event. A service-role-only proof must not silently satisfy an authenticated path. Per `qor/references/doctrine-runtime-principal-fidelity.md`.
 
 #### Visual Silence Verification (if frontend)
 ```
@@ -342,6 +345,18 @@ qor-logic scripts skill_size_budget_lint --skills-root qor/skills || true
 ```
 
 WARN-only V1: the lint emits one finding per oversized SKILL.md but does not abort substantiate. CLI exits 1 when any EXCEEDED finding (>= 40 KB) is present so V2 can convert to a hard ABORT by removing the `|| true` wrap. Operator-actionable: skills exceeding the WARN threshold should be candidates for progressive-disclosure refactor (move sub-pass / step prose to `references/` files); skills exceeding EXCEEDED should be considered overdue for refactor.
+
+### Step 4.6.10: Data-API access-control lint (Phase 121 wiring; GH #177)
+
+**Prerequisite (Phase 75; GH #38)**: requires `module:qor.scripts.data_api_acl_lint`. See Step Prerequisites table; on hosts/repos with no SQL migrations the lint prints a `SKIP:` line and exits 0 (disclosed-skip — record SKIP in the seal entry and emit a `gate_skipped_prerequisite_absent` shadow event).
+
+Static scan over the target repo's SQL migrations. Fail-closed on blocking findings (`missing-grant` — an API-schema `CREATE TABLE` with no `GRANT` to authenticated/anon and no service-role-only marker; `definer-view` — a view without `security_invoker = true`). `security-definer-fn` is advisory. Closes the privileged-principal false-PASS surface from GH #177 (a feature broken for its authenticated caller sealing green because tests ran under `service_role`).
+
+```bash
+qor-logic scripts data_api_acl_lint --repo-root . || ABORT
+```
+
+Escapes: `-- qor:service-role-only` (intentional service-role-only table) and `-- qor:definer-view-intended reason: ...` (intentional definer view). Full contract: `qor/references/doctrine-runtime-principal-fidelity.md`.
 
 ### Step 4.7: Documentation Integrity Check (Phase 28 wiring)
 

--- a/qor/dist/variants/gemini/commands/qor-audit.toml
+++ b/qor/dist/variants/gemini/commands/qor-audit.toml
@@ -251,6 +251,14 @@ Scan for critical security issues:
 - [ ] No `// security: disabled for testing`
 ```
 
+**Data-API access-control checklist (Phase 121 wiring; GH #177)** — plan-level review of any DB surface the plan introduces (the deterministic SQL scan runs at `/qor-substantiate` Step 4.6.10, where migrations exist; here the Judge reviews declared intent):
+
+- [ ] Every API-exposed `CREATE TABLE` the plan introduces commits to explicit `GRANT`s to its runtime roles (platform defaults are not assumable and have changed)
+- [ ] `SECURITY DEFINER` functions and definer-rights (non-`security_invoker`) views over RLS-bearing tables are flagged and access-scoped (a definer-rights view bypasses base-table RLS for any reader)
+- [ ] A feature whose runtime caller is authenticated/anon but whose tests construct a privileged (service-role) client is insufficient proof of the access path
+
+Per `qor/references/doctrine-runtime-principal-fidelity.md`.
+
 **Any violation -> VETO with L3 flag**
 
 **Required next action:** `/qor-debug` (treat as code-logic defect per `qor/references/doctrine-audit-report-language.md`). If the violation is a plan-text gap rather than a runtime defect, the directive becomes: Governor: amend plan text, re-run `/qor-audit`.

--- a/qor/dist/variants/gemini/commands/qor-substantiate.toml
+++ b/qor/dist/variants/gemini/commands/qor-substantiate.toml
@@ -50,6 +50,7 @@ This skill is multi-step; each step declares its prerequisite so non-Python host
 | 4.6.5 secret_scanner | module:qor.scripts.secret_scanner | OWASP LLM06 / NIST AI 600-1 §2.10 |
 | 4.6.6 procedural_fidelity | module:qor.scripts.procedural_fidelity | WARN-only doc-surface coverage gap |
 | 4.7 doc_integrity (strict) | module:qor.scripts.doc_integrity | tier-driven glossary + orphan + term-drift checks |
+| 4.6.10 data_api_acl_lint | module:qor.scripts.data_api_acl_lint | Phase 121 fail-closed Data-API grant/definer-view scan (#177); absent migrations -> disclosed-skip |
 | 4.7.5 governance_index enforce | module:qor.scripts.governance_index | Phase 120 fail-closed index enforcement (advance Last-Reviewed + unregistered/tier3-unarchived) |
 | 6.5 doc currency + badge currency | module:qor.scripts.doc_integrity_strict | release-class badge ABORT (Phase 49) |
 | 6.8 seal hash integrity gate | module:qor.scripts.hash_guard | Phase 64 fail-closed gate |
@@ -175,6 +176,8 @@ Read: Test files
 Template: `references/qor-substantiate-templates.md`.
 
 **Presence-only seal gate**: substantiation refuses to seal if any test added in the current phase is presence-only for the unit it claims to verify. Operator runs the acceptance question — "If the unit's behavior were silently broken but the artifact still existed, would this test fail?" — against each new test in the phase. Any "no" answer ABORTs seal. The operator amends the test to invoke the unit and assert against its output, then re-runs `/qor-substantiate`. Per `qor/references/doctrine-test-functionality.md` and SG-035 ("doctrine-content test unanchored").
+
+**Runtime-principal fidelity gate (Phase 121 wiring; GH #177)**: for any feature whose acceptance includes a DB read/write reachable by a non-privileged caller (authenticated/anon), confirm at least one test exercises that path under the real caller role. If the path is proven only under `service_role` or a `SECURITY DEFINER` RPC (which bypass RLS + table GRANTs), ABORT the seal — UNLESS the operator records an explicit coverage-gap note in the seal entry ("data path verified only under service_role; authenticated/RLS path deferred to manual QA") and emits a `gate_skipped_prerequisite_absent` shadow event. A service-role-only proof must not silently satisfy an authenticated path. Per `qor/references/doctrine-runtime-principal-fidelity.md`.
 
 #### Visual Silence Verification (if frontend)
 ```
@@ -325,6 +328,18 @@ qor-logic scripts skill_size_budget_lint --skills-root qor/skills || true
 ```
 
 WARN-only V1: the lint emits one finding per oversized SKILL.md but does not abort substantiate. CLI exits 1 when any EXCEEDED finding (>= 40 KB) is present so V2 can convert to a hard ABORT by removing the `|| true` wrap. Operator-actionable: skills exceeding the WARN threshold should be candidates for progressive-disclosure refactor (move sub-pass / step prose to `references/` files); skills exceeding EXCEEDED should be considered overdue for refactor.
+
+### Step 4.6.10: Data-API access-control lint (Phase 121 wiring; GH #177)
+
+**Prerequisite (Phase 75; GH #38)**: requires `module:qor.scripts.data_api_acl_lint`. See Step Prerequisites table; on hosts/repos with no SQL migrations the lint prints a `SKIP:` line and exits 0 (disclosed-skip — record SKIP in the seal entry and emit a `gate_skipped_prerequisite_absent` shadow event).
+
+Static scan over the target repo's SQL migrations. Fail-closed on blocking findings (`missing-grant` — an API-schema `CREATE TABLE` with no `GRANT` to authenticated/anon and no service-role-only marker; `definer-view` — a view without `security_invoker = true`). `security-definer-fn` is advisory. Closes the privileged-principal false-PASS surface from GH #177 (a feature broken for its authenticated caller sealing green because tests ran under `service_role`).
+
+```bash
+qor-logic scripts data_api_acl_lint --repo-root . || ABORT
+```
+
+Escapes: `-- qor:service-role-only` (intentional service-role-only table) and `-- qor:definer-view-intended reason: ...` (intentional definer view). Full contract: `qor/references/doctrine-runtime-principal-fidelity.md`.
 
 ### Step 4.7: Documentation Integrity Check (Phase 28 wiring)
 

--- a/qor/dist/variants/gemini/manifest.json
+++ b/qor/dist/variants/gemini/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-05-30T07:07:40Z",
+  "generated_ts": "2026-06-01T23:14:38Z",
   "files": [
     {
       "id": "agent-agent-architect.toml",
@@ -96,7 +96,7 @@
       "id": "qor-audit.toml",
       "source_path": "commands/qor-audit.toml",
       "install_rel_path": "commands/qor-audit.toml",
-      "sha256": "4fc7de5fc5a9fb7de2b7f4de114ae4aa22410885718d8ee13fae1021269a26af"
+      "sha256": "400c0ca3d07f63e819e271dbe200b8422ae7381b938629ade912ed78128bf5f3"
     },
     {
       "id": "qor-bootstrap.toml",
@@ -252,7 +252,7 @@
       "id": "qor-substantiate.toml",
       "source_path": "commands/qor-substantiate.toml",
       "install_rel_path": "commands/qor-substantiate.toml",
-      "sha256": "8ed72eb18d9bb6968e37e8fdef53865837f520d39d936e8248690a5c7ad895f7"
+      "sha256": "66dacef4ca65739b1629a280fc43f24c99e051ad518fb26e40f58c54e510edb8"
     },
     {
       "id": "qor-tone.toml",

--- a/qor/dist/variants/kilo-code/manifest.json
+++ b/qor/dist/variants/kilo-code/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-05-30T07:07:40Z",
+  "generated_ts": "2026-06-01T23:14:38Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "c9d9e4949c7f7299e27998c18cdb83aacaca031689193582d3f537f04f402700"
+      "sha256": "b18c6c9e63e1590d44e33fa4cd11d05e96b702663bb14c3fd2387081adfb11db"
     },
     {
       "id": "qor-bootstrap",
@@ -390,7 +390,7 @@
       "id": "qor-substantiate",
       "source_path": "skills/qor-substantiate/SKILL.md",
       "install_rel_path": "skills/qor-substantiate/SKILL.md",
-      "sha256": "aff3e0b33d2a9d90f52ea77ccaf832c983655633e25b6cb8e2a61e2fe2275f2b"
+      "sha256": "50de4d4d2ae323ec7ff0ac197e0f49e36fcf5c3a79ba13b014d2aa1dd464fbc2"
     },
     {
       "id": "qor-tone",

--- a/qor/dist/variants/kilo-code/skills/qor-audit/SKILL.md
+++ b/qor/dist/variants/kilo-code/skills/qor-audit/SKILL.md
@@ -268,6 +268,14 @@ Scan for critical security issues:
 - [ ] No `// security: disabled for testing`
 ```
 
+**Data-API access-control checklist (Phase 121 wiring; GH #177)** — plan-level review of any DB surface the plan introduces (the deterministic SQL scan runs at `/qor-substantiate` Step 4.6.10, where migrations exist; here the Judge reviews declared intent):
+
+- [ ] Every API-exposed `CREATE TABLE` the plan introduces commits to explicit `GRANT`s to its runtime roles (platform defaults are not assumable and have changed)
+- [ ] `SECURITY DEFINER` functions and definer-rights (non-`security_invoker`) views over RLS-bearing tables are flagged and access-scoped (a definer-rights view bypasses base-table RLS for any reader)
+- [ ] A feature whose runtime caller is authenticated/anon but whose tests construct a privileged (service-role) client is insufficient proof of the access path
+
+Per `qor/references/doctrine-runtime-principal-fidelity.md`.
+
 **Any violation -> VETO with L3 flag**
 
 **Required next action:** `/qor-debug` (treat as code-logic defect per `qor/references/doctrine-audit-report-language.md`). If the violation is a plan-text gap rather than a runtime defect, the directive becomes: Governor: amend plan text, re-run `/qor-audit`.

--- a/qor/dist/variants/kilo-code/skills/qor-substantiate/SKILL.md
+++ b/qor/dist/variants/kilo-code/skills/qor-substantiate/SKILL.md
@@ -67,6 +67,7 @@ This skill is multi-step; each step declares its prerequisite so non-Python host
 | 4.6.5 secret_scanner | module:qor.scripts.secret_scanner | OWASP LLM06 / NIST AI 600-1 §2.10 |
 | 4.6.6 procedural_fidelity | module:qor.scripts.procedural_fidelity | WARN-only doc-surface coverage gap |
 | 4.7 doc_integrity (strict) | module:qor.scripts.doc_integrity | tier-driven glossary + orphan + term-drift checks |
+| 4.6.10 data_api_acl_lint | module:qor.scripts.data_api_acl_lint | Phase 121 fail-closed Data-API grant/definer-view scan (#177); absent migrations -> disclosed-skip |
 | 4.7.5 governance_index enforce | module:qor.scripts.governance_index | Phase 120 fail-closed index enforcement (advance Last-Reviewed + unregistered/tier3-unarchived) |
 | 6.5 doc currency + badge currency | module:qor.scripts.doc_integrity_strict | release-class badge ABORT (Phase 49) |
 | 6.8 seal hash integrity gate | module:qor.scripts.hash_guard | Phase 64 fail-closed gate |
@@ -192,6 +193,8 @@ Read: Test files
 Template: `references/qor-substantiate-templates.md`.
 
 **Presence-only seal gate**: substantiation refuses to seal if any test added in the current phase is presence-only for the unit it claims to verify. Operator runs the acceptance question — "If the unit's behavior were silently broken but the artifact still existed, would this test fail?" — against each new test in the phase. Any "no" answer ABORTs seal. The operator amends the test to invoke the unit and assert against its output, then re-runs `/qor-substantiate`. Per `qor/references/doctrine-test-functionality.md` and SG-035 ("doctrine-content test unanchored").
+
+**Runtime-principal fidelity gate (Phase 121 wiring; GH #177)**: for any feature whose acceptance includes a DB read/write reachable by a non-privileged caller (authenticated/anon), confirm at least one test exercises that path under the real caller role. If the path is proven only under `service_role` or a `SECURITY DEFINER` RPC (which bypass RLS + table GRANTs), ABORT the seal — UNLESS the operator records an explicit coverage-gap note in the seal entry ("data path verified only under service_role; authenticated/RLS path deferred to manual QA") and emits a `gate_skipped_prerequisite_absent` shadow event. A service-role-only proof must not silently satisfy an authenticated path. Per `qor/references/doctrine-runtime-principal-fidelity.md`.
 
 #### Visual Silence Verification (if frontend)
 ```
@@ -342,6 +345,18 @@ qor-logic scripts skill_size_budget_lint --skills-root qor/skills || true
 ```
 
 WARN-only V1: the lint emits one finding per oversized SKILL.md but does not abort substantiate. CLI exits 1 when any EXCEEDED finding (>= 40 KB) is present so V2 can convert to a hard ABORT by removing the `|| true` wrap. Operator-actionable: skills exceeding the WARN threshold should be candidates for progressive-disclosure refactor (move sub-pass / step prose to `references/` files); skills exceeding EXCEEDED should be considered overdue for refactor.
+
+### Step 4.6.10: Data-API access-control lint (Phase 121 wiring; GH #177)
+
+**Prerequisite (Phase 75; GH #38)**: requires `module:qor.scripts.data_api_acl_lint`. See Step Prerequisites table; on hosts/repos with no SQL migrations the lint prints a `SKIP:` line and exits 0 (disclosed-skip — record SKIP in the seal entry and emit a `gate_skipped_prerequisite_absent` shadow event).
+
+Static scan over the target repo's SQL migrations. Fail-closed on blocking findings (`missing-grant` — an API-schema `CREATE TABLE` with no `GRANT` to authenticated/anon and no service-role-only marker; `definer-view` — a view without `security_invoker = true`). `security-definer-fn` is advisory. Closes the privileged-principal false-PASS surface from GH #177 (a feature broken for its authenticated caller sealing green because tests ran under `service_role`).
+
+```bash
+qor-logic scripts data_api_acl_lint --repo-root . || ABORT
+```
+
+Escapes: `-- qor:service-role-only` (intentional service-role-only table) and `-- qor:definer-view-intended reason: ...` (intentional definer view). Full contract: `qor/references/doctrine-runtime-principal-fidelity.md`.
 
 ### Step 4.7: Documentation Integrity Check (Phase 28 wiring)
 

--- a/qor/references/doctrine-runtime-principal-fidelity.md
+++ b/qor/references/doctrine-runtime-principal-fidelity.md
@@ -1,0 +1,94 @@
+# Doctrine: Runtime-principal fidelity + Data-API access-control
+
+**Phase 121; GH #177.** Home for the terms *runtime-principal fidelity* and
+*Data-API access-control lint*. Progressive-disclosure target for the short
+steps in `qor-substantiate` (Step 4 + Step 4.6.10) and `qor-audit` (Security Pass).
+
+## Root cause
+
+A governance false-PASS class: the verifying principal has more privilege than
+the runtime caller, so a test exercises a path that does not exist for real
+users. Concretely, on a Postgres/Supabase Data API:
+
+- Tests construct the client with the **service-role key**, or call a
+  `SECURITY DEFINER` RPC that runs as the table owner. Both bypass row-level
+  security (RLS) and table-level `GRANT`s.
+- The feature reads/writes a table that is `REVOKE`d from `authenticated`, or a
+  newly-created table that never received its Data-API `GRANT` (the platform
+  removed the legacy automatic grant for new tables).
+- The suite passes; the authenticated/anon caller hits `42501` in production.
+
+`qor-substantiate` returned PASS on code broken for its real caller. This
+doctrine closes that surface.
+
+## Runtime-principal fidelity (the term)
+
+**runtime-principal fidelity** — the property that a feature's access path is
+proven under the principal that actually calls it at runtime (`authenticated` /
+`anon`), not only under a privileged principal (`service_role`, or a
+`SECURITY DEFINER` function running as owner).
+
+### Acceptance question (qor-substantiate Step 4 gate)
+
+For any feature whose acceptance includes a DB read/write reachable by a
+non-privileged caller: *"Is there at least one test or assertion that exercises
+this path under the real caller role?"* If the path is proven **only** under
+`service_role` / a `SECURITY DEFINER` RPC, the seal ABORTs — **unless** the
+operator records an explicit coverage-gap note in the seal entry
+(the disclosed-skip):
+
+> data path verified only under service_role; authenticated/RLS path deferred to
+> manual QA
+
+and emits a `gate_skipped_prerequisite_absent`-style shadow event. A
+service-role-only proof must not *silently* satisfy a path used by authenticated
+callers. Fail-closed with a disclosed escape, not WARN-only.
+
+## Data-API access-control lint (the term)
+
+**Data-API access-control lint** — `qor.scripts.data_api_acl_lint`, a static
+scan over a target repo's SQL migrations, invoked fail-closed at
+`qor-substantiate` Step 4.6.10 (`|| ABORT`). It runs against the implemented
+SQL, not a live database.
+
+### Finding kinds
+
+| kind | blocking? | meaning | escape |
+|---|---|---|---|
+| `missing-grant` | yes | a `CREATE TABLE` in an API-exposed schema with no `GRANT` to `authenticated`/`anon`, no `REVOKE ... FROM authenticated/anon`, and no escape comment | `-- qor:service-role-only` on/above the `CREATE TABLE`, or an explicit `REVOKE` |
+| `definer-view` | yes | a view in an API schema created without `security_invoker = true` (Postgres default is definer-rights, which bypasses base-table RLS for any reader) | `-- qor:definer-view-intended reason: ...` on/above the `CREATE VIEW` |
+| `security-definer-fn` | no (advisory) | a `SECURITY DEFINER` function — surfaced for review (these are often legitimate) | n/a (review, not block) |
+
+When no migration files are found, the lint records a Phase 75 disclosed-skip
+(`SKIP:` line, exit 0) rather than failing — non-Postgres / unseeded repos are
+out of scope by construction.
+
+### Postgres `security_invoker` citation
+
+Postgres 15+ supports `CREATE VIEW ... WITH (security_invoker = true)`, which
+makes the view run with the *querying* user's privileges (so base-table RLS
+applies). The default (`security_invoker = false`) runs the view with the
+*view owner's* privileges, bypassing base-table RLS for any reader. See the
+PostgreSQL `CREATE VIEW` reference
+(https://www.postgresql.org/docs/current/sql-createview.html,
+"security_invoker"). The lint is a static text scan and does not depend on a
+live database to evaluate this option.
+
+## Where each check lives (substantiate vs audit)
+
+GH #177 frames the grant/view checklist under `qor-audit` (remediation B). But
+`qor-audit` reviews the **plan/blueprint pre-implementation**, when the SQL
+migrations do not yet exist; the implemented SQL exists at **seal time**.
+Therefore:
+
+- **`qor-substantiate`** carries the deterministic executable lint (Step 4.6.10,
+  fail-closed over real migrations) **and** the runtime-principal fidelity
+  acceptance gate (Step 4).
+- **`qor-audit`** carries the plan-level checklist (prompt-contract): the
+  auditor confirms the plan commits to `GRANT`s for any API-exposed table it
+  introduces, flags `SECURITY DEFINER` functions and definer-rights views over
+  RLS tables, and treats a service-role-client test for an authenticated-caller
+  feature as insufficient proof. Any plan-level violation → VETO.
+
+De-complecting: detection of implemented reality (substantiate, deterministic)
+is separated from review of declared intent (audit, judgment).

--- a/qor/references/glossary.md
+++ b/qor/references/glossary.md
@@ -758,6 +758,7 @@ referenced_by:
   - qor/skills/governance/qor-substantiate/SKILL.md
   - qor/references/doctrine-shadow-genome-countermeasures.md
   - qor/references/doctrine-governance-index.md
+  - qor/references/doctrine-runtime-principal-fidelity.md
 introduced_in_plan: phase75-skill-capability-declaration
 ```
 
@@ -1106,4 +1107,22 @@ referenced_by:
   - qor/skills/governance/qor-substantiate/SKILL.md
   - qor/skills/governance/qor-validate/SKILL.md
 introduced_in_plan: phase120-governance-index-enforcement
+```
+```yaml
+term: runtime-principal fidelity
+definition: 'The property (Phase 121; GH #177) that a feature DB access path is proven under the principal that calls it at runtime (authenticated/anon), not only under a privileged principal (service_role or a SECURITY DEFINER function running as owner). qor-substantiate Step 4 fail-closes the seal when a non-privileged path is proven only under service_role, unless the operator records an explicit disclosed coverage-gap note.'
+home: qor/references/doctrine-runtime-principal-fidelity.md
+referenced_by:
+  - qor/skills/governance/qor-substantiate/SKILL.md
+introduced_in_plan: phase121-runtime-principal-fidelity
+```
+```yaml
+term: Data-API access-control lint
+definition: 'qor.scripts.data_api_acl_lint (Phase 121; GH #177): a static SQL-migration scan invoked fail-closed at qor-substantiate Step 4.6.10 (|| ABORT). Flags missing-grant (API-schema CREATE TABLE with no GRANT to authenticated/anon and no service-role-only marker) and definer-view (view without security_invoker = true) as blocking; security-definer-fn is advisory. Absent migrations -> Phase 75 disclosed-skip. Escapes: -- qor:service-role-only and -- qor:definer-view-intended.'
+home: qor/references/doctrine-runtime-principal-fidelity.md
+referenced_by:
+  - qor/scripts/data_api_acl_lint.py
+  - qor/skills/governance/qor-substantiate/SKILL.md
+  - qor/skills/governance/qor-audit/SKILL.md
+introduced_in_plan: phase121-runtime-principal-fidelity
 ```

--- a/qor/scripts/data_api_acl_lint.py
+++ b/qor/scripts/data_api_acl_lint.py
@@ -1,0 +1,215 @@
+"""Data-API access-control lint (Phase 121; GH #177).
+
+Static SQL scan over a target repo's migration files. Flags the deterministic,
+high-confidence access-control defects that survive a privileged-principal test
+(service_role / SECURITY DEFINER) but break for the runtime caller
+(authenticated / anon):
+
+  missing-grant   -- a table in an API-exposed schema with no GRANT to a
+                     non-owner runtime role, no REVOKE marking it
+                     service-role-only, and no `-- qor:service-role-only` escape.
+  definer-view    -- a view in an API schema created without
+                     `security_invoker = true` (Postgres default is
+                     definer-rights, bypassing base-table RLS), no
+                     `-- qor:definer-view-intended` escape.
+  security-definer-fn -- advisory: each SECURITY DEFINER function (reviewed,
+                     not blocked).
+
+Not a live database probe. De-complected: pure `parse_*` helpers (str -> list)
+feed `analyze` (policy), which feeds `main` (process exit).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_API_SCHEMAS = ("public",)
+MIGRATION_GLOBS = (
+    "supabase/migrations/*.sql",
+    "migrations/*.sql",
+    "db/migrations/*.sql",
+    "db/**/*.sql",
+)
+KNOWN_FINDING_KINDS = ("missing-grant", "definer-view", "security-definer-fn")
+BLOCKING_KINDS = ("missing-grant", "definer-view")
+RUNTIME_ROLES = ("authenticated", "anon")
+
+_TABLE_RE = re.compile(
+    r"create\s+table\s+(?:if\s+not\s+exists\s+)?([\w.\"]+)", re.IGNORECASE
+)
+_GRANT_RE = re.compile(
+    r"grant\s+[\w,\s]+?\s+on\s+(?:table\s+)?([\w.\"]+)\s+to\s+([\w\"]+)",
+    re.IGNORECASE,
+)
+_REVOKE_RE = re.compile(
+    r"revoke\s+[\w,\s]+?\s+on\s+(?:table\s+)?([\w.\"]+)\s+from\s+([\w\"]+)",
+    re.IGNORECASE,
+)
+_VIEW_RE = re.compile(
+    r"create\s+(?:or\s+replace\s+)?(?:materialized\s+)?view\s+"
+    r"(?:if\s+not\s+exists\s+)?([\w.\"]+)(.*?)\bas\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_FUNC_RE = re.compile(
+    r"create\s+(?:or\s+replace\s+)?function\s+([\w.\"]+)", re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class AclFinding:
+    kind: str
+    object_name: str
+    file: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class AclResult:
+    findings: tuple[AclFinding, ...]
+    skipped: bool
+    skip_reason: str
+
+
+def _norm(name: str, api_schemas: tuple[str, ...]) -> tuple[str, str]:
+    """Return (schema, bare_name) lowercased, quotes stripped; default schema
+    is the first API schema when unqualified."""
+    cleaned = name.replace('"', "").lower()
+    if "." in cleaned:
+        schema, _, bare = cleaned.partition(".")
+        return schema, bare
+    return api_schemas[0], cleaned
+
+
+def find_sql_migrations(base: Path) -> list[Path]:
+    found: set[Path] = set()
+    for pattern in MIGRATION_GLOBS:
+        found.update(p for p in base.glob(pattern) if p.is_file())
+    return sorted(found)
+
+
+def parse_created_tables(sql: str) -> list[str]:
+    return [m.group(1) for m in _TABLE_RE.finditer(sql)]
+
+
+def parse_grants(sql: str) -> list[tuple[str, str]]:
+    return [(m.group(1), m.group(2)) for m in _GRANT_RE.finditer(sql)]
+
+
+def parse_revokes(sql: str) -> list[tuple[str, str]]:
+    return [(m.group(1), m.group(2)) for m in _REVOKE_RE.finditer(sql)]
+
+
+def parse_views(sql: str) -> list[tuple[str, bool]]:
+    out: list[tuple[str, bool]] = []
+    for m in _VIEW_RE.finditer(sql):
+        options = m.group(2)
+        invoker = bool(re.search(r"security_invoker\s*=\s*(?:true|on)", options, re.IGNORECASE))
+        out.append((m.group(1), invoker))
+    return out
+
+
+def parse_definer_functions(sql: str) -> list[str]:
+    starts = [(m.start(), m.group(1)) for m in _FUNC_RE.finditer(sql)]
+    out: list[str] = []
+    for i, (pos, name) in enumerate(starts):
+        end = starts[i + 1][0] if i + 1 < len(starts) else len(sql)
+        if re.search(r"security\s+definer", sql[pos:end], re.IGNORECASE):
+            out.append(name)
+    return out
+
+
+def _marker_near(sql: str, obj_start: int, marker: str) -> bool:
+    """True when `marker` appears on the object's line or the 3 lines above it."""
+    head = sql[:obj_start].splitlines()
+    window = head[-3:] if len(head) >= 3 else head
+    return any(marker in line for line in window)
+
+
+def _table_starts(sql: str) -> dict[str, int]:
+    return {m.group(1): m.start() for m in _TABLE_RE.finditer(sql)}
+
+
+def _view_starts(sql: str) -> dict[str, int]:
+    return {m.group(1): m.start() for m in _VIEW_RE.finditer(sql)}
+
+
+def analyze(base: Path, api_schemas: tuple[str, ...] = DEFAULT_API_SCHEMAS) -> AclResult:
+    migrations = find_sql_migrations(base)
+    if not migrations:
+        return AclResult((), True, "no SQL migrations found")
+
+    sources = [(p, p.read_text(encoding="utf-8")) for p in migrations]
+    corpus = "\n".join(sql for _, sql in sources)
+
+    granted = {_norm(o, api_schemas) for o, role in parse_grants(corpus)
+               if role.replace('"', "").lower() in RUNTIME_ROLES}
+    revoked = {_norm(o, api_schemas) for o, role in parse_revokes(corpus)
+               if role.replace('"', "").lower() in RUNTIME_ROLES}
+
+    findings: list[AclFinding] = []
+    for path, sql in sources:
+        rel = path.as_posix()
+        starts = _table_starts(sql)
+        for raw in parse_created_tables(sql):
+            schema, bare = _norm(raw, api_schemas)
+            if schema not in api_schemas:
+                continue
+            key = (schema, bare)
+            if key in granted or key in revoked:
+                continue
+            if _marker_near(sql, starts.get(raw, 0), "qor:service-role-only"):
+                continue
+            findings.append(AclFinding(
+                "missing-grant", f"{schema}.{bare}", rel,
+                "table in API schema has no GRANT to authenticated/anon and "
+                "is not marked service-role-only",
+            ))
+        vstarts = _view_starts(sql)
+        for raw, invoker in parse_views(sql):
+            schema, bare = _norm(raw, api_schemas)
+            if schema not in api_schemas or invoker:
+                continue
+            if _marker_near(sql, vstarts.get(raw, 0), "qor:definer-view-intended"):
+                continue
+            findings.append(AclFinding(
+                "definer-view", f"{schema}.{bare}", rel,
+                "view created without security_invoker = true (bypasses base-table RLS)",
+            ))
+        for raw in parse_definer_functions(sql):
+            schema, bare = _norm(raw, api_schemas)
+            findings.append(AclFinding(
+                "security-definer-fn", f"{schema}.{bare}", rel,
+                "SECURITY DEFINER function -- review that it does not bypass RLS",
+            ))
+
+    return AclResult(tuple(findings), False, "")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="data_api_acl_lint")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--api-schemas", default="public")
+    args = parser.parse_args(argv)
+
+    schemas = tuple(s.strip().lower() for s in args.api_schemas.split(",") if s.strip())
+    result = analyze(Path(args.repo_root), schemas or DEFAULT_API_SCHEMAS)
+
+    if result.skipped:
+        print(f"SKIP: {result.skip_reason} (Phase 75 disclosed-skip)")
+        return 0
+
+    for f in result.findings:
+        tag = "BLOCK" if f.kind in BLOCKING_KINDS else "WARN"
+        print(f"[{tag}] {f.kind} {f.object_name} ({f.file}): {f.detail}")
+
+    blocking = [f for f in result.findings if f.kind in BLOCKING_KINDS]
+    if blocking:
+        print(f"data_api_acl_lint: {len(blocking)} blocking finding(s)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qor/skills/governance/qor-audit/SKILL.md
+++ b/qor/skills/governance/qor-audit/SKILL.md
@@ -268,6 +268,14 @@ Scan for critical security issues:
 - [ ] No `// security: disabled for testing`
 ```
 
+**Data-API access-control checklist (Phase 121 wiring; GH #177)** — plan-level review of any DB surface the plan introduces (the deterministic SQL scan runs at `/qor-substantiate` Step 4.6.10, where migrations exist; here the Judge reviews declared intent):
+
+- [ ] Every API-exposed `CREATE TABLE` the plan introduces commits to explicit `GRANT`s to its runtime roles (platform defaults are not assumable and have changed)
+- [ ] `SECURITY DEFINER` functions and definer-rights (non-`security_invoker`) views over RLS-bearing tables are flagged and access-scoped (a definer-rights view bypasses base-table RLS for any reader)
+- [ ] A feature whose runtime caller is authenticated/anon but whose tests construct a privileged (service-role) client is insufficient proof of the access path
+
+Per `qor/references/doctrine-runtime-principal-fidelity.md`.
+
 **Any violation -> VETO with L3 flag**
 
 **Required next action:** `/qor-debug` (treat as code-logic defect per `qor/references/doctrine-audit-report-language.md`). If the violation is a plan-text gap rather than a runtime defect, the directive becomes: Governor: amend plan text, re-run `/qor-audit`.

--- a/qor/skills/governance/qor-substantiate/SKILL.md
+++ b/qor/skills/governance/qor-substantiate/SKILL.md
@@ -67,6 +67,7 @@ This skill is multi-step; each step declares its prerequisite so non-Python host
 | 4.6.5 secret_scanner | module:qor.scripts.secret_scanner | OWASP LLM06 / NIST AI 600-1 §2.10 |
 | 4.6.6 procedural_fidelity | module:qor.scripts.procedural_fidelity | WARN-only doc-surface coverage gap |
 | 4.7 doc_integrity (strict) | module:qor.scripts.doc_integrity | tier-driven glossary + orphan + term-drift checks |
+| 4.6.10 data_api_acl_lint | module:qor.scripts.data_api_acl_lint | Phase 121 fail-closed Data-API grant/definer-view scan (#177); absent migrations -> disclosed-skip |
 | 4.7.5 governance_index enforce | module:qor.scripts.governance_index | Phase 120 fail-closed index enforcement (advance Last-Reviewed + unregistered/tier3-unarchived) |
 | 6.5 doc currency + badge currency | module:qor.scripts.doc_integrity_strict | release-class badge ABORT (Phase 49) |
 | 6.8 seal hash integrity gate | module:qor.scripts.hash_guard | Phase 64 fail-closed gate |
@@ -192,6 +193,8 @@ Read: Test files
 Template: `references/qor-substantiate-templates.md`.
 
 **Presence-only seal gate**: substantiation refuses to seal if any test added in the current phase is presence-only for the unit it claims to verify. Operator runs the acceptance question — "If the unit's behavior were silently broken but the artifact still existed, would this test fail?" — against each new test in the phase. Any "no" answer ABORTs seal. The operator amends the test to invoke the unit and assert against its output, then re-runs `/qor-substantiate`. Per `qor/references/doctrine-test-functionality.md` and SG-035 ("doctrine-content test unanchored").
+
+**Runtime-principal fidelity gate (Phase 121 wiring; GH #177)**: for any feature whose acceptance includes a DB read/write reachable by a non-privileged caller (authenticated/anon), confirm at least one test exercises that path under the real caller role. If the path is proven only under `service_role` or a `SECURITY DEFINER` RPC (which bypass RLS + table GRANTs), ABORT the seal — UNLESS the operator records an explicit coverage-gap note in the seal entry ("data path verified only under service_role; authenticated/RLS path deferred to manual QA") and emits a `gate_skipped_prerequisite_absent` shadow event. A service-role-only proof must not silently satisfy an authenticated path. Per `qor/references/doctrine-runtime-principal-fidelity.md`.
 
 #### Visual Silence Verification (if frontend)
 ```
@@ -342,6 +345,18 @@ qor-logic scripts skill_size_budget_lint --skills-root qor/skills || true
 ```
 
 WARN-only V1: the lint emits one finding per oversized SKILL.md but does not abort substantiate. CLI exits 1 when any EXCEEDED finding (>= 40 KB) is present so V2 can convert to a hard ABORT by removing the `|| true` wrap. Operator-actionable: skills exceeding the WARN threshold should be candidates for progressive-disclosure refactor (move sub-pass / step prose to `references/` files); skills exceeding EXCEEDED should be considered overdue for refactor.
+
+### Step 4.6.10: Data-API access-control lint (Phase 121 wiring; GH #177)
+
+**Prerequisite (Phase 75; GH #38)**: requires `module:qor.scripts.data_api_acl_lint`. See Step Prerequisites table; on hosts/repos with no SQL migrations the lint prints a `SKIP:` line and exits 0 (disclosed-skip — record SKIP in the seal entry and emit a `gate_skipped_prerequisite_absent` shadow event).
+
+Static scan over the target repo's SQL migrations. Fail-closed on blocking findings (`missing-grant` — an API-schema `CREATE TABLE` with no `GRANT` to authenticated/anon and no service-role-only marker; `definer-view` — a view without `security_invoker = true`). `security-definer-fn` is advisory. Closes the privileged-principal false-PASS surface from GH #177 (a feature broken for its authenticated caller sealing green because tests ran under `service_role`).
+
+```bash
+qor-logic scripts data_api_acl_lint --repo-root . || ABORT
+```
+
+Escapes: `-- qor:service-role-only` (intentional service-role-only table) and `-- qor:definer-view-intended reason: ...` (intentional definer view). Full contract: `qor/references/doctrine-runtime-principal-fidelity.md`.
 
 ### Step 4.7: Documentation Integrity Check (Phase 28 wiring)
 

--- a/tests/test_data_api_acl_lint.py
+++ b/tests/test_data_api_acl_lint.py
@@ -1,0 +1,129 @@
+"""Behavioral tests for qor.scripts.data_api_acl_lint (Phase 121; GH #177).
+
+Each test invokes the unit (analyze / main / parse_*) and asserts on its output,
+not on artifact presence. Synthetic SQL is written under a tmp migrations dir.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qor.scripts import data_api_acl_lint as acl
+
+
+def _write_migration(base: Path, name: str, sql: str) -> Path:
+    d = base / "supabase" / "migrations"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / name
+    p.write_text(sql, encoding="utf-8")
+    return p
+
+
+def _kinds(result: acl.AclResult) -> list[str]:
+    return [f.kind for f in result.findings]
+
+
+def test_missing_grant_flagged(tmp_path: Path) -> None:
+    _write_migration(tmp_path, "0001_init.sql", "CREATE TABLE public.items (id int);\n")
+    result = acl.analyze(tmp_path)
+    grant_findings = [f for f in result.findings if f.kind == "missing-grant"]
+    assert len(grant_findings) == 1
+    assert "public.items" in grant_findings[0].object_name
+
+
+def test_grant_to_authenticated_clears(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path,
+        "0001_init.sql",
+        "CREATE TABLE public.items (id int);\n"
+        "GRANT SELECT ON public.items TO authenticated;\n",
+    )
+    result = acl.analyze(tmp_path)
+    assert "missing-grant" not in _kinds(result)
+
+
+def test_service_role_only_escape_clears(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path,
+        "0001_init.sql",
+        "-- qor:service-role-only\n"
+        "CREATE TABLE public.secrets (id int);\n"
+        "REVOKE ALL ON public.secrets FROM authenticated;\n",
+    )
+    result = acl.analyze(tmp_path)
+    assert "missing-grant" not in _kinds(result)
+
+
+def test_definer_view_flagged(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path,
+        "0002_view.sql",
+        "CREATE VIEW public.v AS SELECT id FROM public.items;\n",
+    )
+    result = acl.analyze(tmp_path)
+    view_findings = [f for f in result.findings if f.kind == "definer-view"]
+    assert len(view_findings) == 1
+    assert "public.v" in view_findings[0].object_name
+
+
+def test_security_invoker_view_clears(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path,
+        "0002_view.sql",
+        "CREATE VIEW public.v WITH (security_invoker = true) "
+        "AS SELECT id FROM public.items;\n",
+    )
+    result = acl.analyze(tmp_path)
+    assert "definer-view" not in _kinds(result)
+
+
+def test_security_definer_fn_is_advisory(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path,
+        "0003_fn.sql",
+        "CREATE FUNCTION public.do_it() RETURNS void "
+        "LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;\n",
+    )
+    result = acl.analyze(tmp_path)
+    assert "security-definer-fn" in _kinds(result)
+    # Advisory only: a SECURITY DEFINER function alone does not fail the gate.
+    assert acl.main(["--repo-root", str(tmp_path)]) == 0
+
+
+def test_main_exit_1_on_blocking(tmp_path: Path) -> None:
+    _write_migration(tmp_path, "0001_init.sql", "CREATE TABLE public.items (id int);\n")
+    assert acl.main(["--repo-root", str(tmp_path)]) == 1
+
+
+def test_main_exit_0_and_skip_line_when_no_migrations(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = acl.main(["--repo-root", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "SKIP:" in out
+
+
+def test_non_api_schema_table_not_flagged(tmp_path: Path) -> None:
+    _write_migration(
+        tmp_path, "0001_init.sql", "CREATE TABLE internal.audit_log (id int);\n"
+    )
+    result = acl.analyze(tmp_path, api_schemas=("public",))
+    assert _kinds(result) == []
+
+
+def test_analyze_skipped_when_no_migrations(tmp_path: Path) -> None:
+    result = acl.analyze(tmp_path)
+    assert result.skipped is True
+    assert result.findings == ()
+
+
+def test_doctrine_documents_finding_kinds() -> None:
+    """Inverse-coverage doc-contract: every emitted finding kind is documented
+    in the reference, so the doc cannot drift from the code."""
+    doc = Path("qor/references/doctrine-runtime-principal-fidelity.md").read_text(
+        encoding="utf-8"
+    )
+    for kind in acl.KNOWN_FINDING_KINDS:
+        assert kind in doc, f"finding kind {kind!r} not documented in reference"

--- a/tests/test_runtime_principal_wiring.py
+++ b/tests/test_runtime_principal_wiring.py
@@ -1,0 +1,43 @@
+"""Prompt-contract wiring tests for Phase 121 (GH #177).
+
+These assert the load-bearing instructions exist in the skill prose with the
+correct fail-closed semantics. If an instruction were weakened (e.g. ABORT
+downgraded to WARN, or the lint invocation dropped) the test fails -- so they
+test the contract's behavior, not mere file presence.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SUBSTANTIATE = Path("qor/skills/governance/qor-substantiate/SKILL.md")
+AUDIT = Path("qor/skills/governance/qor-audit/SKILL.md")
+
+
+def test_substantiate_has_runtime_principal_gate() -> None:
+    text = SUBSTANTIATE.read_text(encoding="utf-8")
+    assert "Runtime-principal fidelity" in text  # prose-lint: ok=prompt-contract
+    # Disclosed coverage-gap escape phrase is the fail-closed exception.
+    assert "data path verified only under service_role" in text  # prose-lint: ok=prompt-contract
+    # The gate must ABORT (fail-closed), not merely warn, within its section.
+    idx = text.index("Runtime-principal fidelity")
+    window = text[idx:idx + 900]
+    assert "ABORT" in window
+
+
+def test_substantiate_invokes_data_api_acl_lint() -> None:
+    text = SUBSTANTIATE.read_text(encoding="utf-8")
+    m = re.search(r"data_api_acl_lint.{0,200}\|\|\s*ABORT", text, re.DOTALL)
+    assert m, "data_api_acl_lint invocation must be followed by || ABORT (fail-closed)"
+
+
+def test_substantiate_has_acl_prerequisite_row() -> None:
+    text = SUBSTANTIATE.read_text(encoding="utf-8")
+    assert "module:qor.scripts.data_api_acl_lint" in text  # prose-lint: ok=prompt-contract
+
+
+def test_audit_security_pass_has_dataapi_items() -> None:
+    text = AUDIT.read_text(encoding="utf-8")
+    assert "explicit `GRANT`s" in text  # prose-lint: ok=prompt-contract
+    assert "non-`security_invoker`" in text  # prose-lint: ok=prompt-contract
+    assert "insufficient proof of the access path" in text  # prose-lint: ok=prompt-contract


### PR DESCRIPTION
Phase 121 (GH #177). Stacked on `phase/120-governance-index-enforcement` (PR #178); shows only the Phase 121 diff. Retarget to `main` after #178 merges.

## What

Closes the **privileged-principal false-PASS class**: tests run under `service_role` / a `SECURITY DEFINER` RPC bypass RLS + table `GRANT`s, so a feature broken for its `authenticated`/`anon` caller seals green (two independent instances in an an external QA exemplar autonomous cycle).

- **`/qor-substantiate` Step 4 — runtime-principal fidelity gate** (prompt-contract, fail-closed): a DB path reachable by a non-privileged caller proven only under `service_role` ABORTs the seal, unless an explicit disclosed coverage-gap note is recorded.
- **`/qor-substantiate` Step 4.6.10 — `data_api_acl_lint` (`|| ABORT`)**: static SQL-migration scan. Blocking findings `missing-grant` (API-schema `CREATE TABLE` with no GRANT to authenticated/anon, no service-role-only marker) and `definer-view` (view without `security_invoker = true`); `security-definer-fn` advisory. Escapes `-- qor:service-role-only` / `-- qor:definer-view-intended`. Absent migrations → Phase 75 disclosed-skip.
- **`/qor-audit` Security Pass**: plan-level Data-API access-control checklist (grants on API tables; definer funcs/views flagged; service-role-client tests insufficient).
- New `qor/references/doctrine-runtime-principal-fidelity.md` + 2 glossary terms.

Design note: the executable lint lives at substantiate (seal time, where SQL exists), not audit (plan time, pre-implementation); audit gets the plan-level checklist. Rationale in the doctrine + audit report.

## Verification

- 15 new tests (behavioral lint + prompt-contract wiring). Full suite: **2127 passed, 3 skipped, 0 failed**.
- Audit PASS (L2, solo). Merkle seal `ac720e6a…`, META_LEDGER entry #314, v0.88.0.
- `data_api_acl_lint --repo-root .` SKIPs clean on this repo (no SQL migrations).

Closes #177. Version tag `v0.88.0` held local (not pushed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Governance citations (doctrine §6)

- Plan: `docs/plan-qor-phase121-runtime-principal-fidelity.md`
- Ledger entry #314
- Merkle seal: `ac720e6a355c71cd4e45dca5071beddd600827e3cf58199ebd6345ff56ee08cc`