### PR TITLE
seal: phase 123 - external-reviewer subprocess bridge (Option B) (v0.90.0) (#160)

### DIFF
--- a/.agent/staging/AUDIT_REPORT.md
+++ b/.agent/staging/AUDIT_REPORT.md
@@ -1,28 +1,33 @@
-# AUDIT REPORT — Phase 122 (Seal regression gate: flip fail-closed + logged override, GH #155)
+# AUDIT REPORT — Phase 123 (External-reviewer subprocess bridge, GH #160)
 
-**Target**: docs/plan-qor-phase122-seal-regression-gate.md
+**Target**: docs/plan-qor-phase123-external-reviewer-bridge.md
 **Verdict**: PASS
-**Risk Grade**: L2 (governance-gate anti-deception; flips existing detector to fail-closed + logged override)
-**Mode**: solo (audit_risk_score: option_b_required=false)
-**Session**: 2026-06-01T2317-5e8be1
-**Note**: re-plan after first-pass Infrastructure Alignment caught that the gap is in the EXISTING `feature_index_verify` (Phase 114), not a new module. Corrected plan modifies that module; no duplication.
+**Risk Grade**: L2 (audit-gate surface; subprocess exec of an operator-configured command, fail-safe fallback)
+**Mode**: solo (audit_risk_score: option_b_required=false). Note: this plan ships the very independent-review bridge whose absence forces solo audits; it cannot bootstrap its own independent review (no reviewer configured in this repo). Recorded, not a violation.
+**Session**: 2026-06-01T2343-9febd5
 
 ## Passes
 
-- **Prompt Injection**: PASS.
-- **Security L3 / OWASP**: PASS. Flips an existing detector from `--warn-only` to fail-closed; adds a logged `--override` (no silent fail-open — A04 honored). No secrets, no injection (argv-form, no new subprocess), no deserialization.
-- **Section 4 Razor**: PASS. Change is a small flag + branch in `main`; detection logic (`tally`) unchanged.
-- **Self-Application Sub-Pass** (originating_remediation=GH #155): PASS. The discipline ("do not silently pass a regression") is proven by behavior: `test_main_aborts_on_outside_scope_regression` asserts the fail-closed exit; `test_main_override_exits_0_and_logs_event` asserts the override is logged, not silent.
-- **Test Functionality**: PASS. Behavioral tests invoke `main` and assert exit codes + the logged event (monkeypatched shadow log); wiring tests assert `|| ABORT` co-occurrence and absence of `--warn-only` in the seal invocation — weakening either fails them.
-- **Feature Test Coverage**: PASS (one MODIFIED row, behavioral descriptor).
-- **Dependency Audit**: PASS (no new deps).
-- **Macro-Level Architecture**: PASS (modifies existing module in correct layer).
-- **Infrastructure Alignment**: PASS. `feature_index_verify` exists (Phase 114) with the `return 1` fail-closed path; Step 6 currently invokes it `--warn-only` (qor-substantiate SKILL.md:421). `write_seal_snapshot`/`read_seal_snapshot` + `.qor/feature_index_snapshots/` baseline exist. The plan modifies real infrastructure; the earlier new-module/git-baseline draft was rejected at this pass.
-- **Filter-Stage / Orphan / Ghost-UI**: PASS / N/A.
+- **Prompt Injection**: PASS (canaries clean).
+- **Security L3**: PASS. The bridge executes a command resolved from `.qorlogic/config.json` (`external_reviewer.command`) — an **operator-trusted** source, not external/network input. Mitigations in the plan: list-form argv (no `shell=True`), reviewer-input passed via **stdin** (not interpolated into argv), `timeout`-bounded, and output **validated** against the contract before use. No secrets, no bypassed checks.
+- **OWASP Top 10**: PASS. A03 — no shell, no argv interpolation of untrusted data. A04 — failure is a value (`ReviewOutcome(status="fallback")`) that degrades to the existing solo path + `capability_shortfall`; no silent fail-open that skips review without a logged signal. A08 — output is `json.loads` + schema-validated, no `eval`/pickle.
+- **Section 4 Razor**: PASS. Four small pure-ish units (`resolve_reviewer_command`, `validate_review_output`, `dispatch_review`, `run_external_review`) + `main`; fallback-as-value keeps branching shallow.
+- **Self-Application Sub-Pass** (originating_remediation=GH #160): PASS. The discipline is "enable genuinely independent review." The plan proves the bridge by behavior — `test_run_external_review_ok_with_stub` (real subprocess via a stub) and the fallback/failure-path tests — rather than asserting prose.
+- **Test Functionality**: PASS. Tests invoke the units and assert outputs (resolved argv, validated bool, parsed verdict, fallback outcome, exit code), using a real stub script for the happy path and a mocked `TimeoutExpired` for the timeout path (no flaky sleep). Wiring tests assert load-bearing co-occurrence (`external_reviewer` + `capability_shortfall`; the doc flip).
+- **Feature Test Coverage**: PASS (one NEW row, behavioral descriptor covering ok + all fallback modes).
+- **Dependency Audit**: PASS. Stdlib `subprocess`/`json` only.
+- **Macro-Level Architecture**: PASS. New module in `qor/scripts`; audit invokes it; contract doc in `references/`.
+- **Infrastructure Alignment**: PASS. `adversarial-mode.md` reviewer I/O contract exists; `should_run_adversarial_mode` exists (qor_audit_runtime); the tolerant config-read pattern exists (`qor.tone._config_tone`); new module declared NEW. `runtime_contract_walk` WARNs expected for the NEW module (WARN-only V2).
+- **Filter-Stage / Orphan / Ghost-UI / Live-Progress**: PASS / N/A.
 
-## Process note
+## Advisory (non-blocking)
 
-The first-pass plan duplicated `feature_index_verify` because the solo author-audit (SG-007 author-momentum) did not survey the full Step 6 wiring. The Infrastructure Alignment Pass is the designed catch; it fired (here, operator-surfaced) and the plan was corrected before implementation. No cycle shipped the duplicate.
+- Document in `adversarial-mode.md` that `external_reviewer.command` is operator-trusted (config-file provenance) and is executed list-form without a shell — so operators understand the trust boundary.
+
+## Process Pattern Advisory
+
+<!-- qor:veto-pattern-advisory -->
+No repeated-VETO pattern detected (first audit of Phase 123; prior two sealed phases are PASS seals).
 
 ## Next action
 

--- a/.qor/gates/2026-06-01T2343-9febd5/audit.json
+++ b/.qor/gates/2026-06-01T2343-9febd5/audit.json
@@ -1,0 +1,17 @@
+{
+  "phase": "audit",
+  "session_id": "2026-06-01T2343-9febd5",
+  "ts": "2026-06-02T03:39:40Z",
+  "target": "docs/plan-qor-phase123-external-reviewer-bridge.md",
+  "verdict": "PASS",
+  "report_path": ".agent/staging/AUDIT_REPORT.md",
+  "risk_grade": "L2",
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.89.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "pass",
+    "ts": "2026-06-02T03:39:40Z"
+  }
+}

--- a/.qor/gates/2026-06-01T2343-9febd5/audit_history.jsonl
+++ b/.qor/gates/2026-06-01T2343-9febd5/audit_history.jsonl
@@ -1,0 +1,1 @@
+{"ai_provenance":{"host":"unknown","human_oversight":"pass","model_family":"unknown","system":"Qor-logic","ts":"2026-06-02T03:39:40Z","version":"0.89.0"},"phase":"audit","report_path":".agent/staging/AUDIT_REPORT.md","risk_grade":"L2","session_id":"2026-06-01T2343-9febd5","target":"docs/plan-qor-phase123-external-reviewer-bridge.md","ts":"2026-06-02T03:39:40Z","verdict":"PASS"}

--- a/.qor/gates/2026-06-01T2343-9febd5/implement.json
+++ b/.qor/gates/2026-06-01T2343-9febd5/implement.json
@@ -1,0 +1,21 @@
+{
+  "phase": "implement",
+  "session_id": "2026-06-01T2343-9febd5",
+  "ts": "2026-06-02T03:42:07Z",
+  "files_touched": [
+    "qor/scripts/external_reviewer.py",
+    "tests/test_external_reviewer.py",
+    "tests/test_external_reviewer_wiring.py",
+    "qor/skills/governance/qor-audit/SKILL.md",
+    "qor/skills/governance/qor-audit/references/adversarial-mode.md",
+    "README.md"
+  ],
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.89.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "absent",
+    "ts": "2026-06-02T03:42:07Z"
+  }
+}

--- a/.qor/gates/2026-06-01T2343-9febd5/plan.json
+++ b/.qor/gates/2026-06-01T2343-9febd5/plan.json
@@ -1,0 +1,30 @@
+{
+  "phase": "plan",
+  "session_id": "2026-06-01T2343-9febd5",
+  "ts": "2026-06-02T03:38:52Z",
+  "plan_path": "docs/plan-qor-phase123-external-reviewer-bridge.md",
+  "phases": [
+    "Phase 1: Bridge logic + CLI",
+    "Phase 2: Audit wiring + reference"
+  ],
+  "ci_commands": [
+    "python -m pytest tests/test_external_reviewer.py tests/test_external_reviewer_wiring.py -q",
+    "python -m pytest -q"
+  ],
+  "doc_tier": "standard",
+  "terms": [
+    {
+      "term": "external-reviewer bridge",
+      "home": "qor/skills/governance/qor-audit/references/adversarial-mode.md"
+    }
+  ],
+  "originating_remediation": "GH #160",
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.89.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "absent",
+    "ts": "2026-06-02T03:38:52Z"
+  }
+}

--- a/.qor/gates/2026-06-01T2343-9febd5/substantiate.json
+++ b/.qor/gates/2026-06-01T2343-9febd5/substantiate.json
@@ -1,0 +1,17 @@
+{
+  "phase": "substantiate",
+  "session_id": "2026-06-01T2343-9febd5",
+  "ts": "2026-06-02T03:47:08Z",
+  "verdict": "PASS",
+  "merkle_seal": "bc182f16e7b05a12c5ea79ee348dbc55d20cec69dee9b837bec8667f027753f6",
+  "content_hash": "8c6196cdef7c2cc30d5891c6570b97d32c92d0b6eac12d14d939fd6513cfb56f",
+  "ledger_entry": 316,
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.90.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "pass",
+    "ts": "2026-06-02T03:47:08Z"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@ file is the user-facing narrative.
 
 ## [Unreleased]
 
+## [0.90.0] - 2026-06-01
+
+_Built via [Qor-logic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)._
+
+### Added
+- **Phase 123 (#160)**: External-reviewer subprocess bridge for `/qor-audit` Option B. New `qor.scripts.external_reviewer` dispatches the #50 reviewer I/O contract to an operator-configured external reviewer (`.qorlogic/config.json` → `external_reviewer.command`, argv) over stdin/stdout JSON, validates the returned verdict against the contract, and degrades to a graceful in-harness `fallback` (logged `capability_shortfall`) when the reviewer is absent, errors, times out, or returns invalid output. Flips `adversarial-mode.md` from "Contract-only specification" to shipped. Closes #50's documented deferral.
+
 ## [0.89.0] - 2026-06-01
+
+_Built via [Qor-logic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)._
 
 ### Changed
 - **Phase 122 (#155)**: Seal-time feature-regression gate flipped **fail-closed**. Phase 114's `feature_index_verify` (outside-scope `verified->unverified` detector vs a prior-seal snapshot) was wired into `/qor-substantiate` Step 6 with `--warn-only`; Step 6 now runs it `|| ABORT` so a regression blocks the PASS seal. New per-seal logged escape `--override` emits a `gate_override` shadow event (`details.gate = feature_index_verify`) — the explicit logged override the #155 AC requires. Snapshot baseline + detection logic unchanged; absent `FEATURE_INDEX.md` still disclosed-skips. Also restored the missing `[0.88.0]` CHANGELOG attribution line.

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
   <a href="https://pypi.org/project/qor-logic/"><img src="https://img.shields.io/pypi/v/qor-logic?color=blue&label=PyPI" alt="PyPI"></a>
   <img src="https://img.shields.io/badge/Python-3.11%2B-blue" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/License-BSL--1.1-orange" alt="License: BSL-1.1">
-  <img src="https://img.shields.io/badge/Tests-2138%20passing-brightgreen" alt="Tests: 2138 passing">
+  <img src="https://img.shields.io/badge/Tests-2150%20passing-brightgreen" alt="Tests: 2150 passing">
   <img src="https://img.shields.io/badge/NIST-SP%20800--218A%20%2B%20AI%20RMF%201.0-004488" alt="NIST SP 800-218A + AI RMF 1.0">
   <img src="https://img.shields.io/badge/OWASP-Top%2010%20%2B%20LLM%20Top%2010-004488" alt="OWASP Top 10 + LLM Top 10">
   <img src="https://img.shields.io/badge/EU%20AI%20Act-aligned-004488" alt="EU AI Act aligned">
   <img src="https://img.shields.io/badge/Skills-30-blue" alt="Skills: 30">
   <img src="https://img.shields.io/badge/Agents-13-blue" alt="Agents: 13">
   <img src="https://img.shields.io/badge/Doctrines-33-blue" alt="Doctrines: 33">
-  <img src="https://img.shields.io/badge/Ledger-315%20entries%20sealed-green" alt="Ledger: 315 entries sealed">
+  <img src="https://img.shields.io/badge/Ledger-316%20entries%20sealed-green" alt="Ledger: 316 entries sealed">
   <img src="https://img.shields.io/badge/Doc%20Tier-system-green" alt="Doc Tier: system">
 </p>
 

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -11557,7 +11557,28 @@ Change class: feature. Tests: 2135 passed / 0 failed / 3 skipped (full suite). A
 **Previous Hash**: `ac720e6a355c71cd4e45dca5071beddd600827e3cf58199ebd6345ff56ee08cc`
 **Chain Hash (Merkle seal)**: `da710312d60f049973c3e3edc8093d31981ce299ccd0370d34969c3155a4e970`
 
+### Entry #316: SESSION SEAL -- Phase 123 external-reviewer subprocess bridge (v0.90.0)
+
+**Timestamp**: 2026-06-02T03:46:44Z
+**Phase**: SUBSTANTIATE (Phase 123; feature)
+**Author**: Judge
+**Change class**: feature
+**Plan**: docs/plan-qor-phase123-external-reviewer-bridge.md
+**Session**: `2026-06-01T2343-9febd5`
+**SSDF Practices**: PO.1.3, PO.1.4, PS.2.1, PS.3.2, PW.1.1, PW.4.1, PW.5.1, PW.9.1
+**Entry ID**: `0da0f89bbedd`
+
+**Scope**: Phase 123 implemented (#160): External-reviewer subprocess bridge for /qor-audit Option B. New qor.scripts.external_reviewer dispatches the #50 reviewer I/O contract (adversarial-mode.md) to an operator-configured external reviewer (.qorlogic/config.json -> external_reviewer.command, argv) over stdin/stdout JSON, validates the returned verdict against the output contract, and degrades to a graceful in-harness fallback (logged capability_shortfall) when the reviewer is absent / errors / times out / returns invalid output. Runs list-form (no shell), timeout-bounded; command is operator-trusted (config provenance). qor-audit Step 1.a wired to run_external_review; adversarial-mode.md flipped contract-only -> shipped. 1 new glossary term. 12 new behavioral+wiring tests. Closes #50's documented deferral. Directly addresses the SG-007 author-momentum gap that nearly shipped a duplicate module in phase 122 this session.
+
+Change class: feature. Tests: 2150 passed / 0 failed / 3 skipped (full suite). Audit PASS (L2 solo).
+
+**Review Boundary**: Operator authorized push + PR post-seal (GH #160).
+
+**Content Hash**: `8c6196cdef7c2cc30d5891c6570b97d32c92d0b6eac12d14d939fd6513cfb56f`
+**Previous Hash**: `da710312d60f049973c3e3edc8093d31981ce299ccd0370d34969c3155a4e970`
+**Chain Hash (Merkle seal)**: `bc182f16e7b05a12c5ea79ee348dbc55d20cec69dee9b837bec8667f027753f6`
+
 ---
 
 *Chain integrity: VALID*
-*Session: SEALED* (Phase 122; v0.89.0 local; operator authorized push + PR)
+*Session: SEALED* (Phase 123; v0.90.0 local; operator authorized push + PR)

--- a/docs/plan-qor-phase123-external-reviewer-bridge.md
+++ b/docs/plan-qor-phase123-external-reviewer-bridge.md
@@ -1,0 +1,116 @@
+# Plan: External-reviewer subprocess bridge (Option B)
+
+**change_class**: feature
+
+**doc_tier**: standard
+
+**terms_introduced**:
+- term: external-reviewer bridge
+  home: qor/skills/governance/qor-audit/references/adversarial-mode.md
+
+**boundaries**:
+- limitations: The bridge dispatches the existing #50 reviewer I/O contract (`adversarial-mode.md`) to an operator-configured external command via subprocess (reviewer-input JSON on stdin, reviewer-output JSON on stdout). It does not bundle a specific reviewer (Codex etc.), parse free-form text, or run the reviewer in-process. The command is resolved from `.qorlogic/config.json` (`external_reviewer.command`, an argv list).
+- non_goals: An env-var override (operator chose config-file only); streaming/interactive review; auto-installing a reviewer; changing the reviewer I/O schema; making Option B mandatory (the Phase 87 auto-dispatch mandate is unchanged).
+- exclusions: Hosts with no `.qorlogic/config.json` or no `external_reviewer.command` field fall back to in-harness review (the existing solo path + `capability_shortfall`); a configured-but-unavailable/timing-out/invalid-output command also falls back (never crashes the audit).
+
+## Open Questions
+
+None. Config mechanism resolved: `.qorlogic/config.json` `external_reviewer.command` (argv list); transport is stdin/stdout JSON; any resolution/dispatch failure degrades to graceful fallback.
+
+## Context
+
+GH #160 (umbrella #147; follow-on to #50). #50 (PR #63, v0.47.0) shipped Option B's specification: Step 1.b, the reviewer input/output schema (`adversarial-mode.md`), and the Phase 87 proactive mandate. The **subprocess bridge** to a genuinely independent reviewer was left documented-but-unimplemented ("Status: Contract-only specification"). Option B can be enforced as a manual/in-harness procedure but cannot dispatch to an external process. This phase ships the bridge. (Direct motivation: this development session's solo author-audit nearly shipped a duplicate module — the exact author-momentum failure independent review exists to catch.)
+
+## Feature Inventory Touches
+
+(`docs/FEATURE_INDEX.md` absent; declared for traceability. Touches `qor/` + skills + tests, not `src/`.)
+
+- entry_id: `n/a` · operation: `NEW` · test_path: `tests/test_external_reviewer.py` · test_descriptor: `external_reviewer.run_external_review returns status=ok with the parsed reviewer verdict when a stub command is configured, and status=fallback (no crash) when the command is absent / errors / times out / returns invalid JSON`
+
+## Phase 1: Bridge logic + CLI (`qor/scripts/external_reviewer.py`)
+
+### Affected Files
+
+- `tests/test_external_reviewer.py` - NEW. Behavioral tests using a stub reviewer script (see Unit Tests). Written first; red before the module exists.
+- `qor/scripts/external_reviewer.py` - NEW. Config resolution + subprocess dispatch + output validation + `main(argv)`.
+
+### Changes
+
+```python
+@dataclass(frozen=True)
+class ReviewOutcome:
+    status: str            # "ok" | "fallback"
+    reason: str            # human-readable (e.g. "no reviewer configured", "timeout")
+    review: dict | None    # the validated reviewer-output object when status == "ok"
+
+def resolve_reviewer_command(config_path: Path) -> list[str] | None:
+    """Read `.qorlogic/config.json` -> external_reviewer.command (argv list).
+    None when the file/field is absent or malformed (tolerant parse, mirrors
+    qor.tone._config_tone)."""
+
+def validate_review_output(obj: object) -> bool:
+    """True iff obj matches the adversarial-mode output contract: dict with a
+    list `critiques`, numeric `confidence`, str `model`, str `ts`."""
+
+def dispatch_review(review_input: dict, command: list[str], *, timeout: float = 120.0) -> dict | None:
+    """Run command (list-form argv, no shell), writing json.dumps(review_input)
+    to stdin; parse stdout as JSON; return it iff validate_review_output passes.
+    None on nonzero exit, TimeoutExpired, OSError, or invalid/!contract JSON."""
+
+def run_external_review(review_input: dict, config_path: Path, *, timeout: float = 120.0) -> ReviewOutcome:
+    """Single entry point. Resolve command; if None -> ReviewOutcome("fallback",
+    "no reviewer configured", None). Else dispatch; failure -> ReviewOutcome(
+    "fallback", <reason>, None); success -> ReviewOutcome("ok", "", review)."""
+
+def main(argv: list[str] | None = None) -> int:
+    """--config PATH --input PATH: run_external_review and print the outcome as
+    JSON to stdout. Exit 0 always (fallback is a valid outcome the audit acts on,
+    not a process error)."""
+```
+
+De-complecting: config resolution, output validation, subprocess dispatch, and the orchestrating `run_external_review` are separate units; `main` is the only side-effecting/process layer. Fallback is a value (`ReviewOutcome`), never an exception.
+
+### Unit Tests
+
+- `tests/test_external_reviewer.py::test_resolve_command_from_config` - write `.qorlogic/config.json` with `{"external_reviewer": {"command": ["py", "r.py"]}}`; `resolve_reviewer_command` returns `["py", "r.py"]`.
+- `::test_resolve_command_absent_returns_none` - no config file -> None; config without the field -> None; malformed JSON -> None.
+- `::test_validate_review_output_accepts_contract` - a dict with `critiques=[]`, `confidence=0.5`, `model="x"`, `ts="..."` -> True; missing `critiques` -> False.
+- `::test_dispatch_review_parses_stub_verdict` - write a stub script that reads stdin and prints a valid output JSON; `dispatch_review(input, [sys.executable, stub])` returns the parsed dict with the stub's `critiques`.
+- `::test_dispatch_review_none_on_invalid_json` - stub prints `not json`; returns None.
+- `::test_dispatch_review_none_on_nonzero_exit` - stub exits 1; returns None.
+- `::test_dispatch_review_none_on_timeout` - monkeypatch `subprocess.run` to raise `TimeoutExpired`; returns None (no flaky real sleep).
+- `::test_run_external_review_fallback_when_unconfigured` - empty tmp config dir; `run_external_review` returns `ReviewOutcome(status="fallback", ...)`, `review is None`.
+- `::test_run_external_review_ok_with_stub` - config points at the stub; returns `status="ok"` and `review["critiques"]` matches the stub.
+- `::test_main_prints_outcome_json` - `main(["--config", cfg, "--input", inp])` prints JSON containing `"status"`; returns 0.
+
+## Phase 2: Audit wiring + reference
+
+### Affected Files
+
+- `tests/test_external_reviewer_wiring.py` - NEW. Prompt-contract assertions on qor-audit SKILL.md + adversarial-mode.md.
+- `qor/skills/governance/qor-audit/SKILL.md` - in Step 1.a, after `should_run_adversarial_mode`, document the bridge: when an external reviewer is configured, dispatch via `qor.scripts.external_reviewer.run_external_review`; on `status == "fallback"` log the existing `capability_shortfall` and proceed solo; on `status == "ok"` synthesize the returned critiques. Keep the existing solo fallback intact.
+- `qor/skills/governance/qor-audit/references/adversarial-mode.md` - flip "Status: Contract-only specification" to note the Phase 123 subprocess bridge (`qor.scripts.external_reviewer`), the `.qorlogic/config.json` `external_reviewer.command` config, and the graceful-fallback contract.
+- `qor/dist/variants/**` - regenerated via `qor-logic compile`.
+
+### Changes
+
+The bridge is additive: `should_run_adversarial_mode` (codex-plugin path) is unchanged; the config-driven bridge is the general mechanism, and absence of configuration reproduces today's solo behavior exactly. No change to the Phase 87 auto-dispatch mandate.
+
+### Unit Tests
+
+- `tests/test_external_reviewer_wiring.py::test_audit_references_bridge_with_fallback` - read `qor-audit/SKILL.md`; assert it names `external_reviewer` AND `capability_shortfall` within the Step 1 region (dispatch + documented fallback).
+- `::test_adversarial_mode_doc_marks_bridge_shipped` - read `adversarial-mode.md`; assert it no longer says "Contract-only specification" and names `qor.scripts.external_reviewer` + `external_reviewer.command`.
+
+## Definition of Done
+
+### Deliverable: external-reviewer subprocess bridge
+
+- **D1**: /qor-audit can dispatch the reviewer-schema input to a configured external process and ingest its verdict, with graceful fallback to in-harness review.
+- **D2**: `qor/scripts/external_reviewer.py` with `resolve_reviewer_command`, `validate_review_output`, `dispatch_review`, `run_external_review`, `main`; dispatchable as `qor-logic scripts external_reviewer`.
+- **D3**: Step 1.a wiring + adversarial-mode.md flip; META_LEDGER seal entry; version bump; variants recompiled.
+- **D4**: `tests/test_external_reviewer.py::test_run_external_review_ok_with_stub` + `::test_run_external_review_fallback_when_unconfigured` + `::test_dispatch_review_none_on_nonzero_exit` + `tests/test_external_reviewer_wiring.py::test_audit_references_bridge_with_fallback`.
+
+## CI Commands
+
+- `python -m pytest tests/test_external_reviewer.py tests/test_external_reviewer_wiring.py -q` — bridge + wiring.
+- `python -m pytest -q` — full suite green before substantiate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qor-logic"
-version = "0.89.0"
+version = "0.90.0"
 description = "Qor-logic S.H.I.E.L.D. governance skills for Claude Code, Kilo Code, and future AI coding hosts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/qor/dist/manifest.json
+++ b/qor/dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-01T23:42:41Z",
+  "generated_ts": "2026-06-02T03:47:07Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -102,7 +102,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/references/adversarial-mode.md",
       "install_rel_path": "skills/qor-audit/references/adversarial-mode.md",
-      "sha256": "d6d16798bac2b2a91c7e424b46c2227a28c3559d45cc77b5d37f151f6bb14e48"
+      "sha256": "27aff6a273045cc46677715280fc3fcacb21e67cfd605612572393d47d44e482"
     },
     {
       "id": "qor-audit",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "b18c6c9e63e1590d44e33fa4cd11d05e96b702663bb14c3fd2387081adfb11db"
+      "sha256": "5e745d331d17c90110270f9b7b6be3adce559cc4475264fa92f9ca805a289558"
     },
     {
       "id": "qor-bootstrap",

--- a/qor/dist/variants/claude/manifest.json
+++ b/qor/dist/variants/claude/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-01T23:42:41Z",
+  "generated_ts": "2026-06-02T03:47:07Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -102,7 +102,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/references/adversarial-mode.md",
       "install_rel_path": "skills/qor-audit/references/adversarial-mode.md",
-      "sha256": "d6d16798bac2b2a91c7e424b46c2227a28c3559d45cc77b5d37f151f6bb14e48"
+      "sha256": "27aff6a273045cc46677715280fc3fcacb21e67cfd605612572393d47d44e482"
     },
     {
       "id": "qor-audit",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "b18c6c9e63e1590d44e33fa4cd11d05e96b702663bb14c3fd2387081adfb11db"
+      "sha256": "5e745d331d17c90110270f9b7b6be3adce559cc4475264fa92f9ca805a289558"
     },
     {
       "id": "qor-bootstrap",

--- a/qor/dist/variants/claude/skills/qor-audit/SKILL.md
+++ b/qor/dist/variants/claude/skills/qor-audit/SKILL.md
@@ -194,7 +194,22 @@ else:
     mode = "solo"
 ```
 
-Adversarial mode contract (input/output schemas) lives in `qor/skills/governance/qor-audit/references/adversarial-mode.md` (TBD — wiring placeholder; full Codex integration is future work).
+Adversarial mode contract (input/output schemas) lives in `qor/skills/governance/qor-audit/references/adversarial-mode.md`.
+
+**External-reviewer subprocess bridge (Phase 123 wiring; GH #160).** When an external reviewer is configured (`.qorlogic/config.json` -> `external_reviewer.command`), dispatch the reviewer-input contract to it via the bridge and ingest its verdict:
+
+```python
+from qor.scripts import external_reviewer
+outcome = external_reviewer.run_external_review(review_input, Path(".qorlogic/config.json"))
+if outcome.status == "ok":
+    # Synthesize outcome.review["critiques"] into the audit as additional findings.
+    mode = "adversarial"
+else:  # "fallback": no reviewer configured, or it errored / timed out / returned invalid output
+    runtime.emit_capability_shortfall("external-reviewer", sid)
+    mode = "solo"
+```
+
+The bridge runs the operator-configured command list-form (no shell), passes the reviewer-input JSON on stdin, validates the returned JSON against the output contract, and degrades to a `fallback` outcome on any failure — so a missing/broken reviewer never blocks the audit; it proceeds solo with the logged shortfall. The Phase 87 author-momentum auto-dispatch mandate is unchanged.
 
 **Phase 68 wiring (GH #50) — Option B: independent reviewer codification.** The pre-Phase-68 block above runs Option A: Codex-plugin-driven Claude+Codex adversarial pairing when the harness exposes it. **Option B** is the fallback (and explicit choice) when Option A is unavailable OR when the auditor was also the plan's author. Per SG-007 (self-audit verification scope bias) and the recurring "author-audit momentum" pattern: when the same LLM agent authors a plan and then audits it, the audit inherits the author's search-path momentum — the locations the author did not check during planning are the same locations the author will not check during audit. Independent reviewers with no plan-authorship context naturally check different sources.
 

--- a/qor/dist/variants/claude/skills/qor-audit/references/adversarial-mode.md
+++ b/qor/dist/variants/claude/skills/qor-audit/references/adversarial-mode.md
@@ -1,6 +1,6 @@
 # qor-audit — Adversarial Mode (Codex Plugin)
 
-**Status**: Contract-only specification. Full Codex-plugin invocation wiring is reserved for the harness profile (`qor/platform/profiles/claude-code-with-codex.md`).
+**Status**: Subprocess bridge implemented (Phase 123; GH #160). `qor.scripts.external_reviewer` dispatches this input/output contract to an operator-configured external reviewer. The command is resolved from `.qorlogic/config.json` -> `external_reviewer.command` (an argv list, **operator-trusted**); it is executed list-form (no shell), the reviewer-input JSON is passed on stdin, and the returned JSON is contract-validated before use. Any failure (no command configured, nonzero exit, timeout, invalid output) degrades to a graceful `fallback` outcome and the audit proceeds in-harness (solo) with a logged `capability_shortfall`. The Codex-plugin path (`should_run_adversarial_mode`) remains the harness-native trigger; the bridge is the general external-process mechanism.
 
 ## Trigger
 

--- a/qor/dist/variants/codex/manifest.json
+++ b/qor/dist/variants/codex/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-01T23:42:41Z",
+  "generated_ts": "2026-06-02T03:47:07Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -102,7 +102,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/references/adversarial-mode.md",
       "install_rel_path": "skills/qor-audit/references/adversarial-mode.md",
-      "sha256": "d6d16798bac2b2a91c7e424b46c2227a28c3559d45cc77b5d37f151f6bb14e48"
+      "sha256": "27aff6a273045cc46677715280fc3fcacb21e67cfd605612572393d47d44e482"
     },
     {
       "id": "qor-audit",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "b18c6c9e63e1590d44e33fa4cd11d05e96b702663bb14c3fd2387081adfb11db"
+      "sha256": "5e745d331d17c90110270f9b7b6be3adce559cc4475264fa92f9ca805a289558"
     },
     {
       "id": "qor-bootstrap",

--- a/qor/dist/variants/codex/skills/qor-audit/SKILL.md
+++ b/qor/dist/variants/codex/skills/qor-audit/SKILL.md
@@ -194,7 +194,22 @@ else:
     mode = "solo"
 ```
 
-Adversarial mode contract (input/output schemas) lives in `qor/skills/governance/qor-audit/references/adversarial-mode.md` (TBD — wiring placeholder; full Codex integration is future work).
+Adversarial mode contract (input/output schemas) lives in `qor/skills/governance/qor-audit/references/adversarial-mode.md`.
+
+**External-reviewer subprocess bridge (Phase 123 wiring; GH #160).** When an external reviewer is configured (`.qorlogic/config.json` -> `external_reviewer.command`), dispatch the reviewer-input contract to it via the bridge and ingest its verdict:
+
+```python
+from qor.scripts import external_reviewer
+outcome = external_reviewer.run_external_review(review_input, Path(".qorlogic/config.json"))
+if outcome.status == "ok":
+    # Synthesize outcome.review["critiques"] into the audit as additional findings.
+    mode = "adversarial"
+else:  # "fallback": no reviewer configured, or it errored / timed out / returned invalid output
+    runtime.emit_capability_shortfall("external-reviewer", sid)
+    mode = "solo"
+```
+
+The bridge runs the operator-configured command list-form (no shell), passes the reviewer-input JSON on stdin, validates the returned JSON against the output contract, and degrades to a `fallback` outcome on any failure — so a missing/broken reviewer never blocks the audit; it proceeds solo with the logged shortfall. The Phase 87 author-momentum auto-dispatch mandate is unchanged.
 
 **Phase 68 wiring (GH #50) — Option B: independent reviewer codification.** The pre-Phase-68 block above runs Option A: Codex-plugin-driven Claude+Codex adversarial pairing when the harness exposes it. **Option B** is the fallback (and explicit choice) when Option A is unavailable OR when the auditor was also the plan's author. Per SG-007 (self-audit verification scope bias) and the recurring "author-audit momentum" pattern: when the same LLM agent authors a plan and then audits it, the audit inherits the author's search-path momentum — the locations the author did not check during planning are the same locations the author will not check during audit. Independent reviewers with no plan-authorship context naturally check different sources.
 

--- a/qor/dist/variants/codex/skills/qor-audit/references/adversarial-mode.md
+++ b/qor/dist/variants/codex/skills/qor-audit/references/adversarial-mode.md
@@ -1,6 +1,6 @@
 # qor-audit — Adversarial Mode (Codex Plugin)
 
-**Status**: Contract-only specification. Full Codex-plugin invocation wiring is reserved for the harness profile (`qor/platform/profiles/claude-code-with-codex.md`).
+**Status**: Subprocess bridge implemented (Phase 123; GH #160). `qor.scripts.external_reviewer` dispatches this input/output contract to an operator-configured external reviewer. The command is resolved from `.qorlogic/config.json` -> `external_reviewer.command` (an argv list, **operator-trusted**); it is executed list-form (no shell), the reviewer-input JSON is passed on stdin, and the returned JSON is contract-validated before use. Any failure (no command configured, nonzero exit, timeout, invalid output) degrades to a graceful `fallback` outcome and the audit proceeds in-harness (solo) with a logged `capability_shortfall`. The Codex-plugin path (`should_run_adversarial_mode`) remains the harness-native trigger; the bridge is the general external-process mechanism.
 
 ## Trigger
 

--- a/qor/dist/variants/gemini/commands/qor-audit.toml
+++ b/qor/dist/variants/gemini/commands/qor-audit.toml
@@ -177,7 +177,22 @@ else:
     mode = "solo"
 ```
 
-Adversarial mode contract (input/output schemas) lives in `qor/skills/governance/qor-audit/references/adversarial-mode.md` (TBD — wiring placeholder; full Codex integration is future work).
+Adversarial mode contract (input/output schemas) lives in `qor/skills/governance/qor-audit/references/adversarial-mode.md`.
+
+**External-reviewer subprocess bridge (Phase 123 wiring; GH #160).** When an external reviewer is configured (`.qorlogic/config.json` -> `external_reviewer.command`), dispatch the reviewer-input contract to it via the bridge and ingest its verdict:
+
+```python
+from qor.scripts import external_reviewer
+outcome = external_reviewer.run_external_review(review_input, Path(".qorlogic/config.json"))
+if outcome.status == "ok":
+    # Synthesize outcome.review["critiques"] into the audit as additional findings.
+    mode = "adversarial"
+else:  # "fallback": no reviewer configured, or it errored / timed out / returned invalid output
+    runtime.emit_capability_shortfall("external-reviewer", sid)
+    mode = "solo"
+```
+
+The bridge runs the operator-configured command list-form (no shell), passes the reviewer-input JSON on stdin, validates the returned JSON against the output contract, and degrades to a `fallback` outcome on any failure — so a missing/broken reviewer never blocks the audit; it proceeds solo with the logged shortfall. The Phase 87 author-momentum auto-dispatch mandate is unchanged.
 
 **Phase 68 wiring (GH #50) — Option B: independent reviewer codification.** The pre-Phase-68 block above runs Option A: Codex-plugin-driven Claude+Codex adversarial pairing when the harness exposes it. **Option B** is the fallback (and explicit choice) when Option A is unavailable OR when the auditor was also the plan's author. Per SG-007 (self-audit verification scope bias) and the recurring "author-audit momentum" pattern: when the same LLM agent authors a plan and then audits it, the audit inherits the author's search-path momentum — the locations the author did not check during planning are the same locations the author will not check during audit. Independent reviewers with no plan-authorship context naturally check different sources.
 

--- a/qor/dist/variants/gemini/manifest.json
+++ b/qor/dist/variants/gemini/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-01T23:42:41Z",
+  "generated_ts": "2026-06-02T03:47:07Z",
   "files": [
     {
       "id": "agent-agent-architect.toml",
@@ -96,7 +96,7 @@
       "id": "qor-audit.toml",
       "source_path": "commands/qor-audit.toml",
       "install_rel_path": "commands/qor-audit.toml",
-      "sha256": "400c0ca3d07f63e819e271dbe200b8422ae7381b938629ade912ed78128bf5f3"
+      "sha256": "d62e6a3b2f2ac30c1e3f7783b07094f6081bd9f7880c4bb6df76c2f5e895aea8"
     },
     {
       "id": "qor-bootstrap.toml",

--- a/qor/dist/variants/kilo-code/manifest.json
+++ b/qor/dist/variants/kilo-code/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-01T23:42:41Z",
+  "generated_ts": "2026-06-02T03:47:07Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -102,7 +102,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/references/adversarial-mode.md",
       "install_rel_path": "skills/qor-audit/references/adversarial-mode.md",
-      "sha256": "d6d16798bac2b2a91c7e424b46c2227a28c3559d45cc77b5d37f151f6bb14e48"
+      "sha256": "27aff6a273045cc46677715280fc3fcacb21e67cfd605612572393d47d44e482"
     },
     {
       "id": "qor-audit",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "b18c6c9e63e1590d44e33fa4cd11d05e96b702663bb14c3fd2387081adfb11db"
+      "sha256": "5e745d331d17c90110270f9b7b6be3adce559cc4475264fa92f9ca805a289558"
     },
     {
       "id": "qor-bootstrap",

--- a/qor/dist/variants/kilo-code/skills/qor-audit/SKILL.md
+++ b/qor/dist/variants/kilo-code/skills/qor-audit/SKILL.md
@@ -194,7 +194,22 @@ else:
     mode = "solo"
 ```
 
-Adversarial mode contract (input/output schemas) lives in `qor/skills/governance/qor-audit/references/adversarial-mode.md` (TBD — wiring placeholder; full Codex integration is future work).
+Adversarial mode contract (input/output schemas) lives in `qor/skills/governance/qor-audit/references/adversarial-mode.md`.
+
+**External-reviewer subprocess bridge (Phase 123 wiring; GH #160).** When an external reviewer is configured (`.qorlogic/config.json` -> `external_reviewer.command`), dispatch the reviewer-input contract to it via the bridge and ingest its verdict:
+
+```python
+from qor.scripts import external_reviewer
+outcome = external_reviewer.run_external_review(review_input, Path(".qorlogic/config.json"))
+if outcome.status == "ok":
+    # Synthesize outcome.review["critiques"] into the audit as additional findings.
+    mode = "adversarial"
+else:  # "fallback": no reviewer configured, or it errored / timed out / returned invalid output
+    runtime.emit_capability_shortfall("external-reviewer", sid)
+    mode = "solo"
+```
+
+The bridge runs the operator-configured command list-form (no shell), passes the reviewer-input JSON on stdin, validates the returned JSON against the output contract, and degrades to a `fallback` outcome on any failure — so a missing/broken reviewer never blocks the audit; it proceeds solo with the logged shortfall. The Phase 87 author-momentum auto-dispatch mandate is unchanged.
 
 **Phase 68 wiring (GH #50) — Option B: independent reviewer codification.** The pre-Phase-68 block above runs Option A: Codex-plugin-driven Claude+Codex adversarial pairing when the harness exposes it. **Option B** is the fallback (and explicit choice) when Option A is unavailable OR when the auditor was also the plan's author. Per SG-007 (self-audit verification scope bias) and the recurring "author-audit momentum" pattern: when the same LLM agent authors a plan and then audits it, the audit inherits the author's search-path momentum — the locations the author did not check during planning are the same locations the author will not check during audit. Independent reviewers with no plan-authorship context naturally check different sources.
 

--- a/qor/dist/variants/kilo-code/skills/qor-audit/references/adversarial-mode.md
+++ b/qor/dist/variants/kilo-code/skills/qor-audit/references/adversarial-mode.md
@@ -1,6 +1,6 @@
 # qor-audit — Adversarial Mode (Codex Plugin)
 
-**Status**: Contract-only specification. Full Codex-plugin invocation wiring is reserved for the harness profile (`qor/platform/profiles/claude-code-with-codex.md`).
+**Status**: Subprocess bridge implemented (Phase 123; GH #160). `qor.scripts.external_reviewer` dispatches this input/output contract to an operator-configured external reviewer. The command is resolved from `.qorlogic/config.json` -> `external_reviewer.command` (an argv list, **operator-trusted**); it is executed list-form (no shell), the reviewer-input JSON is passed on stdin, and the returned JSON is contract-validated before use. Any failure (no command configured, nonzero exit, timeout, invalid output) degrades to a graceful `fallback` outcome and the audit proceeds in-harness (solo) with a logged `capability_shortfall`. The Codex-plugin path (`should_run_adversarial_mode`) remains the harness-native trigger; the bridge is the general external-process mechanism.
 
 ## Trigger
 

--- a/qor/references/glossary.md
+++ b/qor/references/glossary.md
@@ -1126,3 +1126,12 @@ referenced_by:
   - qor/skills/governance/qor-audit/SKILL.md
 introduced_in_plan: phase121-runtime-principal-fidelity
 ```
+```yaml
+term: external-reviewer bridge
+definition: 'qor.scripts.external_reviewer (Phase 123; GH #160): the subprocess bridge that dispatches the #50 adversarial-mode reviewer I/O contract to an operator-configured external reviewer (.qorlogic/config.json -> external_reviewer.command, argv) over stdin/stdout JSON, validates the returned verdict, and degrades to a graceful in-harness fallback (logged capability_shortfall) on any failure. Flips adversarial-mode.md from contract-only to shipped.'
+home: qor/skills/governance/qor-audit/references/adversarial-mode.md
+referenced_by:
+  - qor/scripts/external_reviewer.py
+  - qor/skills/governance/qor-audit/SKILL.md
+introduced_in_plan: phase123-external-reviewer-bridge
+```

--- a/qor/scripts/external_reviewer.py
+++ b/qor/scripts/external_reviewer.py
@@ -1,0 +1,122 @@
+"""External-reviewer subprocess bridge (Phase 123; GH #160).
+
+Dispatches the #50 reviewer I/O contract (qor-audit/references/adversarial-mode.md)
+to an operator-configured external reviewer process and ingests its verdict, with
+graceful fallback to in-harness review when the reviewer is absent or fails.
+
+The command is resolved from `.qorlogic/config.json` -> `external_reviewer.command`
+(an argv list, operator-trusted). Transport is JSON over stdin/stdout. The command
+runs list-form (no shell), is timeout-bounded, and its output is contract-validated
+before use. Any failure is returned as a `ReviewOutcome(status="fallback")` value,
+never raised — the audit then proceeds solo and logs `capability_shortfall`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+_DEFAULT_TIMEOUT = 120.0
+
+
+@dataclass(frozen=True)
+class ReviewOutcome:
+    status: str          # "ok" | "fallback"
+    reason: str
+    review: dict | None
+
+
+def resolve_reviewer_command(config_path: Path) -> list[str] | None:
+    """Read `.qorlogic/config.json` -> external_reviewer.command (argv list).
+    Tolerant parse (mirrors qor.tone._config_tone): None on absent file/field or
+    malformed JSON."""
+    if not config_path.exists():
+        return None
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    section = data.get("external_reviewer")
+    if not isinstance(section, dict):
+        return None
+    command = section.get("command")
+    if isinstance(command, list) and command and all(isinstance(x, str) for x in command):
+        return command
+    return None
+
+
+def validate_review_output(obj: object) -> bool:
+    """True iff obj matches the adversarial-mode output contract."""
+    if not isinstance(obj, dict):
+        return False
+    if not isinstance(obj.get("critiques"), list):
+        return False
+    if not isinstance(obj.get("confidence"), (int, float)) or isinstance(obj.get("confidence"), bool):
+        return False
+    if not isinstance(obj.get("model"), str):
+        return False
+    return isinstance(obj.get("ts"), str)
+
+
+def dispatch_review(
+    review_input: dict, command: list[str], *, timeout: float = _DEFAULT_TIMEOUT
+) -> dict | None:
+    """Run command (list-form, no shell), write review_input JSON to stdin, parse
+    stdout as JSON. None on nonzero exit, timeout, OSError, or non-contract JSON."""
+    try:
+        proc = subprocess.run(
+            command,
+            input=json.dumps(review_input),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        parsed = json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return parsed if validate_review_output(parsed) else None
+
+
+def run_external_review(
+    review_input: dict, config_path: Path, *, timeout: float = _DEFAULT_TIMEOUT
+) -> ReviewOutcome:
+    """Single entry point. Resolve the command and dispatch; any miss/failure is a
+    `fallback` outcome (never an exception)."""
+    command = resolve_reviewer_command(config_path)
+    if command is None:
+        return ReviewOutcome("fallback", "no reviewer configured", None)
+    review = dispatch_review(review_input, command, timeout=timeout)
+    if review is None:
+        return ReviewOutcome("fallback", "reviewer unavailable or returned invalid output", None)
+    return ReviewOutcome("ok", "", review)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="external_reviewer")
+    parser.add_argument("--config", default=".qorlogic/config.json")
+    parser.add_argument("--input", required=True, help="path to reviewer-input JSON")
+    parser.add_argument("--timeout", type=float, default=_DEFAULT_TIMEOUT)
+    args = parser.parse_args(argv)
+
+    try:
+        review_input = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(json.dumps({"status": "fallback", "reason": f"bad input: {exc}", "review": None}))
+        return 0
+
+    outcome = run_external_review(review_input, Path(args.config), timeout=args.timeout)
+    print(json.dumps({"status": outcome.status, "reason": outcome.reason, "review": outcome.review}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qor/skills/governance/qor-audit/SKILL.md
+++ b/qor/skills/governance/qor-audit/SKILL.md
@@ -194,7 +194,22 @@ else:
     mode = "solo"
 ```
 
-Adversarial mode contract (input/output schemas) lives in `qor/skills/governance/qor-audit/references/adversarial-mode.md` (TBD — wiring placeholder; full Codex integration is future work).
+Adversarial mode contract (input/output schemas) lives in `qor/skills/governance/qor-audit/references/adversarial-mode.md`.
+
+**External-reviewer subprocess bridge (Phase 123 wiring; GH #160).** When an external reviewer is configured (`.qorlogic/config.json` -> `external_reviewer.command`), dispatch the reviewer-input contract to it via the bridge and ingest its verdict:
+
+```python
+from qor.scripts import external_reviewer
+outcome = external_reviewer.run_external_review(review_input, Path(".qorlogic/config.json"))
+if outcome.status == "ok":
+    # Synthesize outcome.review["critiques"] into the audit as additional findings.
+    mode = "adversarial"
+else:  # "fallback": no reviewer configured, or it errored / timed out / returned invalid output
+    runtime.emit_capability_shortfall("external-reviewer", sid)
+    mode = "solo"
+```
+
+The bridge runs the operator-configured command list-form (no shell), passes the reviewer-input JSON on stdin, validates the returned JSON against the output contract, and degrades to a `fallback` outcome on any failure — so a missing/broken reviewer never blocks the audit; it proceeds solo with the logged shortfall. The Phase 87 author-momentum auto-dispatch mandate is unchanged.
 
 **Phase 68 wiring (GH #50) — Option B: independent reviewer codification.** The pre-Phase-68 block above runs Option A: Codex-plugin-driven Claude+Codex adversarial pairing when the harness exposes it. **Option B** is the fallback (and explicit choice) when Option A is unavailable OR when the auditor was also the plan's author. Per SG-007 (self-audit verification scope bias) and the recurring "author-audit momentum" pattern: when the same LLM agent authors a plan and then audits it, the audit inherits the author's search-path momentum — the locations the author did not check during planning are the same locations the author will not check during audit. Independent reviewers with no plan-authorship context naturally check different sources.
 

--- a/qor/skills/governance/qor-audit/references/adversarial-mode.md
+++ b/qor/skills/governance/qor-audit/references/adversarial-mode.md
@@ -1,6 +1,6 @@
 # qor-audit — Adversarial Mode (Codex Plugin)
 
-**Status**: Contract-only specification. Full Codex-plugin invocation wiring is reserved for the harness profile (`qor/platform/profiles/claude-code-with-codex.md`).
+**Status**: Subprocess bridge implemented (Phase 123; GH #160). `qor.scripts.external_reviewer` dispatches this input/output contract to an operator-configured external reviewer. The command is resolved from `.qorlogic/config.json` -> `external_reviewer.command` (an argv list, **operator-trusted**); it is executed list-form (no shell), the reviewer-input JSON is passed on stdin, and the returned JSON is contract-validated before use. Any failure (no command configured, nonzero exit, timeout, invalid output) degrades to a graceful `fallback` outcome and the audit proceeds in-harness (solo) with a logged `capability_shortfall`. The Codex-plugin path (`should_run_adversarial_mode`) remains the harness-native trigger; the bridge is the general external-process mechanism.
 
 ## Trigger
 

--- a/tests/test_external_reviewer.py
+++ b/tests/test_external_reviewer.py
@@ -1,0 +1,114 @@
+"""Behavioral tests for qor.scripts.external_reviewer (Phase 123; GH #160).
+
+Happy path uses a real stub reviewer subprocess; the timeout path mocks
+subprocess.run to raise TimeoutExpired (no flaky real sleep).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from qor.scripts import external_reviewer as er
+
+_VALID_OUTPUT = {
+    "critiques": [{"severity": "L2", "claim_challenged": "x",
+                   "counter_evidence": "y", "recommended_gap": "z"}],
+    "confidence": 0.7,
+    "model": "stub",
+    "ts": "2026-01-01T00:00:00Z",
+}
+
+
+def _stub(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "stub_reviewer.py"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _ok_stub(tmp_path: Path) -> list[str]:
+    body = (
+        "import sys, json\n"
+        "json.load(sys.stdin)\n"
+        f"print(json.dumps({_VALID_OUTPUT!r}))\n"
+    )
+    return [sys.executable, str(_stub(tmp_path, body))]
+
+
+def _config(tmp_path: Path, command: list[str]) -> Path:
+    cfg_dir = tmp_path / ".qorlogic"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg = cfg_dir / "config.json"
+    cfg.write_text(json.dumps({"external_reviewer": {"command": command}}), encoding="utf-8")
+    return cfg
+
+
+def test_resolve_command_from_config(tmp_path: Path) -> None:
+    cfg = _config(tmp_path, ["py", "r.py"])
+    assert er.resolve_reviewer_command(cfg) == ["py", "r.py"]
+
+
+def test_resolve_command_absent_returns_none(tmp_path: Path) -> None:
+    assert er.resolve_reviewer_command(tmp_path / "nope.json") is None
+    empty = tmp_path / "empty.json"
+    empty.write_text("{}", encoding="utf-8")
+    assert er.resolve_reviewer_command(empty) is None
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert er.resolve_reviewer_command(bad) is None
+
+
+def test_validate_review_output_accepts_contract() -> None:
+    assert er.validate_review_output(_VALID_OUTPUT) is True
+    assert er.validate_review_output({"confidence": 1, "model": "m", "ts": "t"}) is False
+    assert er.validate_review_output("nope") is False
+
+
+def test_dispatch_review_parses_stub_verdict(tmp_path: Path) -> None:
+    out = er.dispatch_review({"plan_path": "p"}, _ok_stub(tmp_path))
+    assert out is not None
+    assert out["critiques"][0]["severity"] == "L2"
+    assert out["model"] == "stub"
+
+
+def test_dispatch_review_none_on_invalid_json(tmp_path: Path) -> None:
+    cmd = [sys.executable, str(_stub(tmp_path, "print('not json')\n"))]
+    assert er.dispatch_review({"x": 1}, cmd) is None
+
+
+def test_dispatch_review_none_on_nonzero_exit(tmp_path: Path) -> None:
+    cmd = [sys.executable, str(_stub(tmp_path, "import sys; sys.exit(1)\n"))]
+    assert er.dispatch_review({"x": 1}, cmd) is None
+
+
+def test_dispatch_review_none_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="r", timeout=0.1)
+    monkeypatch.setattr(er.subprocess, "run", _raise)
+    assert er.dispatch_review({"x": 1}, ["r"]) is None
+
+
+def test_run_external_review_fallback_when_unconfigured(tmp_path: Path) -> None:
+    outcome = er.run_external_review({"plan_path": "p"}, tmp_path / ".qorlogic" / "config.json")
+    assert outcome.status == "fallback"
+    assert outcome.review is None
+
+
+def test_run_external_review_ok_with_stub(tmp_path: Path) -> None:
+    cfg = _config(tmp_path, _ok_stub(tmp_path))
+    outcome = er.run_external_review({"plan_path": "p"}, cfg)
+    assert outcome.status == "ok"
+    assert outcome.review["critiques"][0]["severity"] == "L2"
+
+
+def test_main_prints_outcome_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cfg = _config(tmp_path, _ok_stub(tmp_path))
+    inp = tmp_path / "input.json"
+    inp.write_text(json.dumps({"plan_path": "p"}), encoding="utf-8")
+    rc = er.main(["--config", str(cfg), "--input", str(inp)])
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["status"] == "ok"

--- a/tests/test_external_reviewer_wiring.py
+++ b/tests/test_external_reviewer_wiring.py
@@ -1,0 +1,22 @@
+"""Prompt-contract wiring tests for Phase 123 (GH #160)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+AUDIT = Path("qor/skills/governance/qor-audit/SKILL.md")
+ADV_MODE = Path("qor/skills/governance/qor-audit/references/adversarial-mode.md")
+
+
+def test_audit_references_bridge_with_fallback() -> None:
+    text = AUDIT.read_text(encoding="utf-8")
+    idx = text.index("Identity Activation")
+    region = text[idx:idx + 2500]
+    assert "external_reviewer" in region  # prose-lint: ok=prompt-contract
+    assert "capability_shortfall" in region  # prose-lint: ok=prompt-contract
+
+
+def test_adversarial_mode_doc_marks_bridge_shipped() -> None:
+    doc = ADV_MODE.read_text(encoding="utf-8")
+    assert "Contract-only specification" not in doc  # prose-lint: ok=prompt-contract
+    assert "qor.scripts.external_reviewer" in doc  # prose-lint: ok=prompt-contract
+    assert "external_reviewer.command" in doc  # prose-lint: ok=prompt-contract


### PR DESCRIPTION
Phase 123 (GH #160). Stacked on `phase/122-seal-regression-gate` (PR #180); retarget to `main` after #180 merges.

## What

Ships the external-reviewer **subprocess bridge** that #50 left documented-but-unimplemented ("Status: Contract-only specification"). New `qor.scripts.external_reviewer`:

- **Dispatches** the existing #50 reviewer I/O contract (`adversarial-mode.md`) to an operator-configured external reviewer resolved from `.qorlogic/config.json` → `external_reviewer.command` (argv), over **stdin/stdout JSON**.
- **Validates** the returned verdict against the output contract before use.
- **Graceful fallback** (`ReviewOutcome(status="fallback")` + logged `capability_shortfall`) when the reviewer is absent, exits nonzero, times out, or returns invalid output — never crashes the audit.
- Runs **list-form (no shell)**, timeout-bounded; the command is operator-trusted (config provenance).

`/qor-audit` Step 1.a wired to `run_external_review`; `adversarial-mode.md` flipped contract-only → shipped. The Codex-plugin path and the Phase 87 auto-dispatch mandate are unchanged.

## Why now

This session's Phase 122 nearly shipped a duplicate module because the audit ran solo (SG-007 author-momentum). This bridge is the mechanism that makes genuinely independent review dispatchable — directly closing that gap.

## Verification

- 12 new tests (config resolution, contract validation, real-subprocess happy path, nonzero/invalid/timeout fallback, wiring). Full suite: **2150 passed, 3 skipped, 0 failed**.
- Audit PASS (L2, solo). Merkle seal `bc182f16...`, META_LEDGER #316, v0.90.0 (tag held local).
- Also fixed the recurring `[0.89.0]` CHANGELOG attribution-line omission (apply_stamp doesn't insert it).

Closes #160 and #50's documented deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Governance citations (doctrine §6)

- Plan: `docs/plan-qor-phase123-external-reviewer-bridge.md`
- Ledger entry #316
- Merkle seal: `bc182f16e7b05a12c5ea79ee348dbc55d20cec69dee9b837bec8667f027753f6`