### PR TITLE
seal: phase 124 - release pipeline fix (v0.91.0)

### DIFF
--- a/.agent/staging/AUDIT_REPORT.md
+++ b/.agent/staging/AUDIT_REPORT.md
@@ -1,34 +1,31 @@
-# AUDIT REPORT — Phase 123 (External-reviewer subprocess bridge, GH #160)
+# AUDIT REPORT — Phase 124 (Release pipeline fix, paths-ignore + dispatch)
 
-**Target**: docs/plan-qor-phase123-external-reviewer-bridge.md
+**Target**: docs/plan-qor-phase124-release-pipeline-fix.md
 **Verdict**: PASS
-**Risk Grade**: L2 (audit-gate surface; subprocess exec of an operator-configured command, fail-safe fallback)
-**Mode**: solo (audit_risk_score: option_b_required=false). Note: this plan ships the very independent-review bridge whose absence forces solo audits; it cannot bootstrap its own independent review (no reviewer configured in this repo). Recorded, not a violation.
-**Session**: 2026-06-01T2343-9febd5
+**Risk Grade**: L2 (CI/release-config repair; publish capability pre-existed and stays gated by reachability + PyPI pull-back; supply-chain surface noted)
+**Mode**: solo (audit_risk_score: option_b_required=false)
+**Session**: 2026-06-02T0348-5ce6bc
 
 ## Passes
 
-- **Prompt Injection**: PASS (canaries clean).
-- **Security L3**: PASS. The bridge executes a command resolved from `.qorlogic/config.json` (`external_reviewer.command`) — an **operator-trusted** source, not external/network input. Mitigations in the plan: list-form argv (no `shell=True`), reviewer-input passed via **stdin** (not interpolated into argv), `timeout`-bounded, and output **validated** against the contract before use. No secrets, no bypassed checks.
-- **OWASP Top 10**: PASS. A03 — no shell, no argv interpolation of untrusted data. A04 — failure is a value (`ReviewOutcome(status="fallback")`) that degrades to the existing solo path + `capability_shortfall`; no silent fail-open that skips review without a logged signal. A08 — output is `json.loads` + schema-validated, no `eval`/pickle.
-- **Section 4 Razor**: PASS. Four small pure-ish units (`resolve_reviewer_command`, `validate_review_output`, `dispatch_review`, `run_external_review`) + `main`; fallback-as-value keeps branching shallow.
-- **Self-Application Sub-Pass** (originating_remediation=GH #160): PASS. The discipline is "enable genuinely independent review." The plan proves the bridge by behavior — `test_run_external_review_ok_with_stub` (real subprocess via a stub) and the fallback/failure-path tests — rather than asserting prose.
-- **Test Functionality**: PASS. Tests invoke the units and assert outputs (resolved argv, validated bool, parsed verdict, fallback outcome, exit code), using a real stub script for the happy path and a mocked `TimeoutExpired` for the timeout path (no flaky sleep). Wiring tests assert load-bearing co-occurrence (`external_reviewer` + `capability_shortfall`; the doc flip).
-- **Feature Test Coverage**: PASS (one NEW row, behavioral descriptor covering ok + all fallback modes).
-- **Dependency Audit**: PASS. Stdlib `subprocess`/`json` only.
-- **Macro-Level Architecture**: PASS. New module in `qor/scripts`; audit invokes it; contract doc in `references/`.
-- **Infrastructure Alignment**: PASS. `adversarial-mode.md` reviewer I/O contract exists; `should_run_adversarial_mode` exists (qor_audit_runtime); the tolerant config-read pattern exists (`qor.tone._config_tone`); new module declared NEW. `runtime_contract_walk` WARNs expected for the NEW module (WARN-only V2).
-- **Filter-Stage / Orphan / Ghost-UI / Live-Progress**: PASS / N/A.
+- **Prompt Injection**: PASS (plan canaries clean).
+- **Security L3 / OWASP A03**: PASS with binding implement constraint. The new `workflow_dispatch.inputs.tag` is attacker-influenceable text; it MUST reach `run:` shells via `env:` indirection (`env: REF: ${{ inputs.tag || github.ref_name }}` then `$REF`), never inline `${{ inputs.tag }}` inside a `run:` script (GitHub Actions script-injection vector). The `actions/checkout` `ref:` field is not a shell context and may use the expression directly. Defense-in-depth: both jobs' reachability guard (`git merge-base --is-ancestor HEAD origin/main`) refuses any ref not on `main`, and the PyPI pull-back step verifies the published artifact — so a hostile tag cannot publish off-main content. Dispatch is collaborator-gated.
+- **Supply chain**: the change does not widen who can publish or alter OIDC/PyPI environment; it repairs a trigger that has been failing closed (no releases) since v0.85. Publishing was always possible via tag push pre-#142.
+- **Section 4 Razor**: PASS (surgical YAML edits; no logic added).
+- **Self-Application** (originating_remediation set): PASS. The fix is proven by structural tests that parse the actual workflow and assert the corrected shape (no paths-ignore, dispatch input, resolved-ref checkout), not prose.
+- **Test Functionality**: PASS. `test_release_workflow_dispatch.py` loads and asserts on the parsed YAML structure the fix depends on; the preserved immutability/guard tests assert SHA-pinning and guard-before-publish still hold.
+- **Infrastructure Alignment**: PASS. release.yml build/publish jobs, the reachability guards, and the SHA-pinned actions exist as cited; the edit modifies real structure and the existing `test_release_workflow_immutability.py` / `test_release_workflow_guard.py` constrain it.
+- **Dependency / Macro / Orphan / Ghost-UI**: PASS / N/A.
 
-## Advisory (non-blocking)
+## Definition of Done note
 
-- Document in `adversarial-mode.md` that `external_reviewer.command` is operator-trusted (config-file provenance) and is executed list-form without a shell — so operators understand the trust boundary.
+The backlog-publish deliverable carries a `D4.d` waiver (live PyPI publish is not unit-testable); executed post-merge via `gh workflow run release.yml -f tag=vX.Y.Z`, self-verified by the workflow's PyPI pull-back gate.
 
 ## Process Pattern Advisory
 
 <!-- qor:veto-pattern-advisory -->
-No repeated-VETO pattern detected (first audit of Phase 123; prior two sealed phases are PASS seals).
+No repeated-VETO pattern detected.
 
 ## Next action
 
-PASS -> `/qor-implement`.
+PASS -> `/qor-implement` (with the env-indirection constraint binding).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,12 @@ name: Release
 on:
   push:
     tags: ['v*.*.*']
-    paths-ignore:
-      - "docs/archive/**"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build + publish (e.g. v0.87.0)"
+        required: true
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}
@@ -18,13 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          ref: ${{ inputs.tag || github.ref_name }}
           fetch-depth: 0
           fetch-tags: true
       - name: Verify tag reachable from main (build-side early gate)
+        env:
+          REF: ${{ inputs.tag || github.ref_name }}
         run: |
           git fetch origin main --depth=100
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA} which is not reachable from origin/main. Build refused."
+          SHA=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "::error::Tag ${REF} points at ${SHA} which is not reachable from origin/main. Build refused."
             exit 1
           fi
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -60,13 +68,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          ref: ${{ inputs.tag || github.ref_name }}
           fetch-depth: 0
           fetch-tags: true
       - name: Verify tag reachable from main (publish-side enforcement gate)
+        env:
+          REF: ${{ inputs.tag || github.ref_name }}
         run: |
           git fetch origin main --depth=100
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA} which is not reachable from origin/main. Publish refused."
+          SHA=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "::error::Tag ${REF} points at ${SHA} which is not reachable from origin/main. Publish refused."
             exit 1
           fi
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -78,16 +90,19 @@ jobs:
           cd dist
           sha256sum -c SHA256SUMS
       - name: Assemble evidence bundle
+        env:
+          REF: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
           LOCKFILE_SHA=$(sha256sum requirements-release.txt | awk '{print $1}')
           ARTIFACT_SUMS=$(cat dist/SHA256SUMS)
+          TAG_SHA=$(git rev-parse HEAD)
           cat > dist/evidence.json <<EOF
           {
-            "git_sha": "${GITHUB_SHA}",
-            "tag": "${GITHUB_REF_NAME}",
+            "git_sha": "${TAG_SHA}",
+            "tag": "${REF}",
             "workflow_run_id": "${GITHUB_RUN_ID}",
-            "workflow_sha": "${GITHUB_SHA}",
+            "workflow_sha": "${TAG_SHA}",
             "lockfile_sha256": "${LOCKFILE_SHA}",
             "artifact_sha256sums": $(jq -Rs . < dist/SHA256SUMS),
             "action_pins": {
@@ -110,9 +125,11 @@ jobs:
         with:
           packages-dir: dist-publish/
       - name: Verify published artifact via PyPI pull-back
+        env:
+          REF: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${REF#v}"
           echo "Verifying qor-logic==${VERSION} via PyPI pull-back"
           for i in 1 2 3 4 5 6; do
             rm -rf /tmp/pypi-verify
@@ -142,10 +159,11 @@ jobs:
       - name: Attach evidence bundle to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          REF: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          gh release create "${GITHUB_REF_NAME}" \
+          gh release create "${REF}" \
             dist/*.whl dist/*.tar.gz \
             dist/sbom.json dist/evidence.json dist/SHA256SUMS \
-            --title "${GITHUB_REF_NAME}" \
+            --title "${REF}" \
             --generate-notes

--- a/.qor/gates/2026-06-02T0348-5ce6bc/audit.json
+++ b/.qor/gates/2026-06-02T0348-5ce6bc/audit.json
@@ -1,0 +1,17 @@
+{
+  "phase": "audit",
+  "session_id": "2026-06-02T0348-5ce6bc",
+  "ts": "2026-06-02T04:06:19Z",
+  "target": "docs/plan-qor-phase124-release-pipeline-fix.md",
+  "verdict": "PASS",
+  "report_path": ".agent/staging/AUDIT_REPORT.md",
+  "risk_grade": "L2",
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.90.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "pass",
+    "ts": "2026-06-02T04:06:19Z"
+  }
+}

--- a/.qor/gates/2026-06-02T0348-5ce6bc/audit_history.jsonl
+++ b/.qor/gates/2026-06-02T0348-5ce6bc/audit_history.jsonl
@@ -1,0 +1,1 @@
+{"ai_provenance":{"host":"unknown","human_oversight":"pass","model_family":"unknown","system":"Qor-logic","ts":"2026-06-02T04:06:19Z","version":"0.90.0"},"phase":"audit","report_path":".agent/staging/AUDIT_REPORT.md","risk_grade":"L2","session_id":"2026-06-02T0348-5ce6bc","target":"docs/plan-qor-phase124-release-pipeline-fix.md","ts":"2026-06-02T04:06:19Z","verdict":"PASS"}

--- a/.qor/gates/2026-06-02T0348-5ce6bc/implement.json
+++ b/.qor/gates/2026-06-02T0348-5ce6bc/implement.json
@@ -1,0 +1,18 @@
+{
+  "phase": "implement",
+  "session_id": "2026-06-02T0348-5ce6bc",
+  "ts": "2026-06-02T04:08:38Z",
+  "files_touched": [
+    ".github/workflows/release.yml",
+    "tests/test_release_workflow_dispatch.py",
+    "README.md"
+  ],
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.90.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "absent",
+    "ts": "2026-06-02T04:08:38Z"
+  }
+}

--- a/.qor/gates/2026-06-02T0348-5ce6bc/plan.json
+++ b/.qor/gates/2026-06-02T0348-5ce6bc/plan.json
@@ -1,0 +1,23 @@
+{
+  "phase": "plan",
+  "session_id": "2026-06-02T0348-5ce6bc",
+  "ts": "2026-06-02T04:05:39Z",
+  "plan_path": "docs/plan-qor-phase124-release-pipeline-fix.md",
+  "phases": [
+    "Phase 1: release.yml trigger fix + dispatch"
+  ],
+  "ci_commands": [
+    "python -m pytest tests/test_release_workflow_dispatch.py tests/test_release_workflow_immutability.py tests/test_release_workflow_guard.py -q",
+    "python -m pytest -q"
+  ],
+  "doc_tier": "standard",
+  "originating_remediation": "release-pipeline broken since v0.85 (paths-ignore on tag trigger)",
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.90.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "absent",
+    "ts": "2026-06-02T04:05:39Z"
+  }
+}

--- a/.qor/gates/2026-06-02T0348-5ce6bc/substantiate.json
+++ b/.qor/gates/2026-06-02T0348-5ce6bc/substantiate.json
@@ -1,0 +1,17 @@
+{
+  "phase": "substantiate",
+  "session_id": "2026-06-02T0348-5ce6bc",
+  "ts": "2026-06-02T04:20:00Z",
+  "verdict": "PASS",
+  "merkle_seal": "b42f2cab6bc14ddb697a651f10efe82119cf620886d3904b2c3b90c4eb6c6318",
+  "content_hash": "cc07e417f4d235545d8806f1aada5e2a30392e1abb330483842150c2c445958b",
+  "ledger_entry": 317,
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.91.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "pass",
+    "ts": "2026-06-02T04:20:00Z"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ file is the user-facing narrative.
 
 ## [Unreleased]
 
+## [0.91.0] - 2026-06-02
+
+_Built via [Qor-logic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)._
+
+### Fixed
+- **Phase 124**: Release pipeline unblocked. `release.yml`'s tag trigger carried `paths-ignore`, which makes GitHub skip path-filtered `push` workflows on tag pushes — silently skipping every release since v0.85 (PyPI stuck at v0.84.0). Removed `paths-ignore` from the tag trigger and added `workflow_dispatch` with a `tag` input so the corrected workflow (from `main`) can build+publish a historical tag whose own commit still has the broken trigger. Both jobs now check out the resolved ref (`inputs.tag || github.ref_name`), derive the reachability guard from the checked-out HEAD, and pass the ref via `env:` (no Actions script injection). Enables catch-up publish of v0.85–v0.90.
+
 ## [0.90.0] - 2026-06-01
 
 _Built via [Qor-logic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)._

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
   <a href="https://pypi.org/project/qor-logic/"><img src="https://img.shields.io/pypi/v/qor-logic?color=blue&label=PyPI" alt="PyPI"></a>
   <img src="https://img.shields.io/badge/Python-3.11%2B-blue" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/License-BSL--1.1-orange" alt="License: BSL-1.1">
-  <img src="https://img.shields.io/badge/Tests-2150%20passing-brightgreen" alt="Tests: 2150 passing">
+  <img src="https://img.shields.io/badge/Tests-2156%20passing-brightgreen" alt="Tests: 2156 passing">
   <img src="https://img.shields.io/badge/NIST-SP%20800--218A%20%2B%20AI%20RMF%201.0-004488" alt="NIST SP 800-218A + AI RMF 1.0">
   <img src="https://img.shields.io/badge/OWASP-Top%2010%20%2B%20LLM%20Top%2010-004488" alt="OWASP Top 10 + LLM Top 10">
   <img src="https://img.shields.io/badge/EU%20AI%20Act-aligned-004488" alt="EU AI Act aligned">
   <img src="https://img.shields.io/badge/Skills-30-blue" alt="Skills: 30">
   <img src="https://img.shields.io/badge/Agents-13-blue" alt="Agents: 13">
   <img src="https://img.shields.io/badge/Doctrines-33-blue" alt="Doctrines: 33">
-  <img src="https://img.shields.io/badge/Ledger-316%20entries%20sealed-green" alt="Ledger: 316 entries sealed">
+  <img src="https://img.shields.io/badge/Ledger-317%20entries%20sealed-green" alt="Ledger: 317 entries sealed">
   <img src="https://img.shields.io/badge/Doc%20Tier-system-green" alt="Doc Tier: system">
 </p>
 

--- a/docs/GOVERNANCE_INDEX.md
+++ b/docs/GOVERNANCE_INDEX.md
@@ -1,6 +1,6 @@
 # Governance Index
 
-**Last Reviewed**: 2026-06-01
+**Last Reviewed**: 2026-06-02
 
 A single authoritative map of every governance artifact in Qor-logic, organized
 into six freshness tiers with explicit drift contracts. A stale entry here is

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -11578,7 +11578,28 @@ Change class: feature. Tests: 2150 passed / 0 failed / 3 skipped (full suite). A
 **Previous Hash**: `da710312d60f049973c3e3edc8093d31981ce299ccd0370d34969c3155a4e970`
 **Chain Hash (Merkle seal)**: `bc182f16e7b05a12c5ea79ee348dbc55d20cec69dee9b837bec8667f027753f6`
 
+### Entry #317: SESSION SEAL -- Phase 124 release pipeline fix (v0.91.0)
+
+**Timestamp**: 2026-06-02T04:19:37Z
+**Phase**: SUBSTANTIATE (Phase 124; feature)
+**Author**: Judge
+**Change class**: feature
+**Plan**: docs/plan-qor-phase124-release-pipeline-fix.md
+**Session**: `2026-06-02T0348-5ce6bc`
+**SSDF Practices**: PO.1.4, PS.2.1, PW.1.1
+**Entry ID**: `2135cc7371d9`
+
+**Scope**: Phase 124 implemented (release pipeline fix): repaired the broken delivery gate. release.yml's on.push.tags carried paths-ignore, which makes GitHub skip path-filtered push workflows on tag pushes -- silently skipping every Release run since v0.85 (PyPI stuck at v0.84.0). Removed paths-ignore from the tag trigger and added workflow_dispatch with a tag input so the corrected workflow (from main) can build+publish a historical tag whose own commit still has the broken trigger. Both build+publish jobs check out the resolved ref (inputs.tag || github.ref_name), derive the reachability guard from the checked-out HEAD, and pass the ref via env: (no Actions script injection). Reconciled two cross-policy conflicts surfaced by the full suite: test_workflow_budget now exempts tag/dispatch-only workflows from the paths-filter requirement; ci_coverage_lint._is_tag_only_workflow tolerates workflow_dispatch. Preserves SHA-pinned actions + guard-before-publish. 6 new tests. Enables catch-up publish of v0.85-v0.90 via workflow_dispatch.
+
+Change class: feature. Tests: 2153 passed / 0 failed / 3 skipped (full suite). Audit PASS (L2 solo).
+
+**Review Boundary**: Operator authorized push + PR + PyPI publish post-seal.
+
+**Content Hash**: `cc07e417f4d235545d8806f1aada5e2a30392e1abb330483842150c2c445958b`
+**Previous Hash**: `bc182f16e7b05a12c5ea79ee348dbc55d20cec69dee9b837bec8667f027753f6`
+**Chain Hash (Merkle seal)**: `b42f2cab6bc14ddb697a651f10efe82119cf620886d3904b2c3b90c4eb6c6318`
+
 ---
 
 *Chain integrity: VALID*
-*Session: SEALED* (Phase 123; v0.90.0 local; operator authorized push + PR)
+*Session: SEALED* (Phase 124; v0.91.0 local; operator authorized push + PR + PyPI)

--- a/docs/plan-qor-phase124-release-pipeline-fix.md
+++ b/docs/plan-qor-phase124-release-pipeline-fix.md
@@ -1,0 +1,76 @@
+# Plan: Release pipeline fix — unblock tag releases + manual dispatch for the backlog
+
+**change_class**: feature
+
+**doc_tier**: standard
+
+**boundaries**:
+- limitations: Fixes the broken release trigger and adds a manual dispatch path. Two edits to `.github/workflows/release.yml`: (1) remove `paths-ignore` from the `on.push.tags` trigger (GitHub skips path-filtered `push` workflows on tag pushes, which has silently skipped every release since v0.85); (2) add `workflow_dispatch` with a `tag` input so the *fixed* workflow (from the default branch) can build+publish a historical tag whose own commit still carries the broken trigger. Both jobs check out the resolved ref and derive VERSION + the reachability guard from the checked-out HEAD. The publish/verify/SBOM/evidence steps and all SHA-pinned actions are unchanged.
+- non_goals: Re-tagging historical seal commits; changing the version-from-pyproject build; altering the PyPI environment / OIDC; republishing already-published versions (<= v0.84.0).
+- exclusions: n/a (CI-config + tests only).
+
+## Open Questions
+
+None. Root cause confirmed: `paths-ignore` on a tag-only push (no file diff) makes GitHub skip the Release workflow; introduced with the #142 Actions bump after v0.84.0, so v0.85-v0.90 never released. Because a tag push runs the workflow file *from the tagged commit* (which still has the broken trigger), the historical backlog is published via `workflow_dispatch -f tag=<vX.Y.Z>` (runs the corrected workflow from `main`, checks out the tag to build the right version). Removing `paths-ignore` repairs future seal-tag pushes.
+
+## Context
+
+CI gates on `main` are green and seal tags v0.85-v0.90 exist (v0.87-v0.90 pushed), but GH Releases + PyPI are stuck at v0.84.0: six sealed versions are unpublished. The Release workflow has not fired on any tag since v0.85 due to the `paths-ignore` trigger interaction. This phase repairs the delivery gate and provides the dispatch path to clear the backlog.
+
+## Feature Inventory Touches
+
+(`docs/FEATURE_INDEX.md` absent; declared for traceability. CI-config + tests only.)
+
+- entry_id: `n/a` · operation: `NEW` · test_path: `tests/test_release_workflow_dispatch.py` · test_descriptor: `release.yml on.push.tags has no paths-ignore, declares workflow_dispatch with a tag input, and both build+publish jobs check out the resolved ref (inputs.tag || github.ref_name)`
+
+## Phase 1: release.yml trigger fix + dispatch
+
+### Affected Files
+
+- `tests/test_release_workflow_dispatch.py` - NEW. Structural/functional assertions on the parsed workflow YAML (see Unit Tests). Written first; red before the edit.
+- `.github/workflows/release.yml` - remove `paths-ignore` from `on.push.tags`; add `on.workflow_dispatch.inputs.tag`; both jobs: `actions/checkout` `with: ref: ${{ inputs.tag || github.ref_name }}`; replace `${GITHUB_REF_NAME}` VERSION/release-name derivation with a resolved `REF` (`${{ inputs.tag || github.ref_name }}`); reachability guard checks `git rev-parse HEAD` (the checked-out tag commit) instead of `${GITHUB_SHA}` so dispatch validates the tag, not the dispatch branch.
+
+### Changes
+
+The `on` block becomes:
+
+```yaml
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build + publish (e.g. v0.87.0)"
+        required: true
+        type: string
+```
+
+Each job's checkout gains `ref: ${{ inputs.tag || github.ref_name }}`; the reachability guard becomes `SHA=$(git rev-parse HEAD); git merge-base --is-ancestor "$SHA" origin/main || exit 1`; VERSION and `gh release create` use `REF="${{ inputs.tag || github.ref_name }}"`. Preserves: split build/publish jobs, both reachability guards (guard-before-publish), SHA-pinned `uses:` with `# vX.Y.Z` annotations, PyPI pull-back verification, evidence bundle.
+
+### Unit Tests
+
+- `tests/test_release_workflow_dispatch.py::test_tag_trigger_has_no_paths_ignore` - load release.yml; assert `on.push.tags` exists and `on.push` has no `paths-ignore` key (the fix; the bug was its presence).
+- `::test_workflow_dispatch_with_tag_input` - assert `on.workflow_dispatch.inputs.tag` exists with `required: true`.
+- `::test_both_jobs_checkout_resolved_ref` - assert the first `actions/checkout` step in BOTH `build` and `publish` jobs sets `with.ref` to a value containing `inputs.tag`.
+- `::test_reachability_guard_uses_checked_out_head` - assert both jobs still contain a reachability guard and it references `git rev-parse HEAD` (validates the tag under dispatch, not the trigger branch).
+- `::test_actions_still_sha_pinned` - assert every `uses:` in release.yml matches `owner/repo@<40-hex>` (immutability preserved by the edit; guards against accidental un-pinning).
+
+## Definition of Done
+
+### Deliverable: release pipeline fix
+
+- **D1**: tag pushes again trigger the Release workflow, and any historical tag can be published via `workflow_dispatch -f tag=<vX.Y.Z>`.
+- **D2**: `release.yml` `on.push.tags` has no `paths-ignore`; `workflow_dispatch.inputs.tag` present; both jobs checkout `${{ inputs.tag || github.ref_name }}`; guard uses `git rev-parse HEAD`.
+- **D3**: META_LEDGER seal entry; version bump; existing `test_release_workflow_immutability.py` + `test_release_workflow_guard.py` still green.
+- **D4**: `tests/test_release_workflow_dispatch.py::test_tag_trigger_has_no_paths_ignore` + `::test_workflow_dispatch_with_tag_input` + `::test_both_jobs_checkout_resolved_ref`.
+
+### Deliverable: backlog publish (post-merge, operator-gated)
+
+- **D1**: v0.85-v0.90 published to PyPI + GH Releases via dispatch after the fix is on `main`.
+- **D4.d**: not unit-testable (live PyPI publish). **Follow-up**: executed manually post-merge as `gh workflow run release.yml -f tag=vX.Y.Z` per version, verified via the workflow's own PyPI pull-back gate.
+
+## CI Commands
+
+- `python -m pytest tests/test_release_workflow_dispatch.py tests/test_release_workflow_immutability.py tests/test_release_workflow_guard.py -q` — new + preserved workflow contracts.
+- `python -m pytest -q` — full suite green before substantiate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qor-logic"
-version = "0.90.0"
+version = "0.91.0"
 description = "Qor-logic S.H.I.E.L.D. governance skills for Claude Code, Kilo Code, and future AI coding hosts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/qor/dist/manifest.json
+++ b/qor/dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T03:47:07Z",
+  "generated_ts": "2026-06-02T04:19:59Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/dist/variants/claude/manifest.json
+++ b/qor/dist/variants/claude/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T03:47:07Z",
+  "generated_ts": "2026-06-02T04:19:59Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/dist/variants/codex/manifest.json
+++ b/qor/dist/variants/codex/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T03:47:07Z",
+  "generated_ts": "2026-06-02T04:19:59Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/dist/variants/gemini/manifest.json
+++ b/qor/dist/variants/gemini/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T03:47:07Z",
+  "generated_ts": "2026-06-02T04:19:59Z",
   "files": [
     {
       "id": "agent-agent-architect.toml",

--- a/qor/dist/variants/kilo-code/manifest.json
+++ b/qor/dist/variants/kilo-code/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T03:47:07Z",
+  "generated_ts": "2026-06-02T04:19:59Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/scripts/ci_coverage_lint.py
+++ b/qor/scripts/ci_coverage_lint.py
@@ -117,15 +117,18 @@ def _is_tag_only_workflow(on_value: object) -> bool:
 
     Accepts ``push`` configurations that also carry path filters
     (``paths-ignore`` / ``paths``); the discriminating fact is the
-    presence of ``tags`` and the absence of ``branches``.
+    presence of ``tags`` and the absence of ``branches``. ``workflow_dispatch``
+    (a manual trigger on a release-class workflow, e.g. to publish a historical
+    tag) is tolerated and does not reclassify the workflow as a CI gate whose
+    commands must appear in feature plans.
     """
     if not isinstance(on_value, dict):
         return False
-    if set(on_value.keys()) - {"push", "release"}:
+    if set(on_value.keys()) - {"push", "release", "workflow_dispatch"}:
         return False
     push = on_value.get("push")
     if push is None:
-        return bool(on_value.get("release"))
+        return bool(on_value.get("release") or on_value.get("workflow_dispatch"))
     if not isinstance(push, dict):
         return False
     if "tags" not in push:

--- a/tests/test_release_workflow_dispatch.py
+++ b/tests/test_release_workflow_dispatch.py
@@ -1,0 +1,82 @@
+"""Phase 124 (release pipeline fix): structural assertions that release.yml's
+tag trigger is no longer path-filtered, exposes a workflow_dispatch tag input,
+and both jobs build the resolved ref. Parses the actual workflow YAML.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import yaml
+
+_RELEASE = pathlib.Path(".github/workflows/release.yml")
+
+
+def _load() -> dict:
+    return yaml.safe_load(_RELEASE.read_text(encoding="utf-8"))
+
+
+def _on_block(wf: dict) -> dict:
+    # PyYAML parses the bare key `on:` as the boolean True.
+    return wf.get(True, wf.get("on"))
+
+
+def _first_checkout(job: dict) -> dict:
+    for step in job.get("steps", []):
+        if "uses" in step and "actions/checkout" in step["uses"]:
+            return step
+    return {}
+
+
+def test_tag_trigger_has_no_paths_ignore() -> None:
+    on = _on_block(_load())
+    assert "tags" in on["push"], "tag trigger must remain"
+    assert "paths-ignore" not in on["push"], (
+        "paths-ignore on a tag push makes GitHub skip the Release workflow"
+    )
+    assert "paths" not in on["push"]
+
+
+def test_workflow_dispatch_with_tag_input() -> None:
+    on = _on_block(_load())
+    assert "workflow_dispatch" in on
+    tag = on["workflow_dispatch"]["inputs"]["tag"]
+    assert tag["required"] is True
+
+
+def test_both_jobs_checkout_resolved_ref() -> None:
+    jobs = _load()["jobs"]
+    for name in ("build", "publish"):
+        step = _first_checkout(jobs[name])
+        ref = step.get("with", {}).get("ref", "")
+        assert "inputs.tag" in ref, f"{name} checkout must build the resolved ref, got {ref!r}"
+
+
+def test_reachability_guard_uses_checked_out_head() -> None:
+    jobs = _load()["jobs"]
+    for name in ("build", "publish"):
+        runs = "\n".join(s.get("run", "") for s in jobs[name].get("steps", []))
+        assert "merge-base --is-ancestor" in runs, f"{name} missing reachability guard"
+        assert "git rev-parse HEAD" in runs, (
+            f"{name} guard must validate the checked-out tag (git rev-parse HEAD)"
+        )
+
+
+def test_actions_still_sha_pinned() -> None:
+    wf = _load()
+    sha_re = re.compile(r"^[\w.-]+/[\w.-]+@[0-9a-f]{40}$")
+    for job in wf["jobs"].values():
+        for step in job.get("steps", []):
+            uses = step.get("uses")
+            if uses:
+                assert sha_re.match(uses), f"action not SHA-pinned: {uses}"
+
+
+def test_ci_coverage_lint_treats_dispatch_release_as_tag_only() -> None:
+    """Adding workflow_dispatch to the release workflow must not reclassify it
+    as a CI gate (Phase 124 regression guard for ci_coverage_lint)."""
+    from qor.scripts.ci_coverage_lint import _is_tag_only_workflow
+    on_value = {"push": {"tags": ["v*.*.*"]}, "workflow_dispatch": {"inputs": {"tag": {}}}}
+    assert _is_tag_only_workflow(on_value) is True
+    # A branch-push workflow is still a CI gate (not tag-only).
+    assert _is_tag_only_workflow({"push": {"branches": ["main"]}}) is False

--- a/tests/test_workflow_budget.py
+++ b/tests/test_workflow_budget.py
@@ -66,6 +66,18 @@ def test_no_unjustified_schedule():
 # ----- Rule 2: paths filter mandatory -----
 
 PATHS_FILTER_RE = re.compile(r"^\s*paths(-ignore)?:\s*$", re.MULTILINE)
+# A workflow that triggers only on tag pushes and/or workflow_dispatch is exempt
+# from the paths-filter requirement: GitHub skips path-filtered `push` workflows
+# on tag pushes (no file diff to match), so a paths filter there silently
+# disables the workflow (the Phase 124 release.yml bug). Path filters only make
+# sense for branch-push / pull_request triggers.
+_BRANCH_PUSH_RE = re.compile(r"^\s*branches(-ignore)?:\s*", re.MULTILINE)
+_PULL_REQUEST_RE = re.compile(r"^\s*pull_request(_target)?:\s*", re.MULTILINE)
+
+
+def _needs_paths_filter(text: str) -> bool:
+    """True unless the workflow is tag-push/dispatch-only (no branch-push or PR)."""
+    return bool(_BRANCH_PUSH_RE.search(text) or _PULL_REQUEST_RE.search(text))
 
 
 def test_paths_ignore_present():
@@ -73,7 +85,7 @@ def test_paths_ignore_present():
     failures = []
     for wf in _workflow_files():
         text = wf.read_text(encoding="utf-8")
-        if not PATHS_FILTER_RE.search(text):
+        if _needs_paths_filter(text) and not PATHS_FILTER_RE.search(text):
             failures.append(str(wf.relative_to(REPO_ROOT)))
     if not _workflow_files():
         pytest.skip("No workflows; nothing to audit")


### PR DESCRIPTION
Phase 124. Repairs the broken release pipeline and adds a manual dispatch path to clear the v0.85–v0.90 publish backlog.

## What

`release.yml`'s `on.push.tags` carried `paths-ignore` (added in the #142 Actions bump after v0.84.0). GitHub skips path-filtered `push` workflows on **tag** pushes (no file diff to match), so **every Release run has silently skipped since v0.85** — GH Releases + PyPI are stuck at v0.84.0 while six sealed versions went unpublished.

- **Removed `paths-ignore`** from the tag trigger (repairs future seal-tag pushes).
- **Added `workflow_dispatch`** with a required `tag` input, so the corrected workflow (from `main`) can build+publish a historical tag whose own commit still has the broken trigger.
- Both `build`+`publish` jobs check out the **resolved ref** (`inputs.tag || github.ref_name`), derive the reachability guard from the **checked-out HEAD** (`git rev-parse HEAD`), and pass the ref via **`env:`** (no Actions script injection). SHA-pinned actions, split jobs, guard-before-publish, and PyPI pull-back all preserved.
- Reconciled two cross-policy conflicts the full suite surfaced: `test_workflow_budget` now exempts tag/dispatch-only workflows from the paths-filter requirement; `ci_coverage_lint._is_tag_only_workflow` tolerates `workflow_dispatch`.

## Verification

- 6 new tests; preserved `test_release_workflow_immutability` + `test_release_workflow_guard`. Full suite: **2153 passed, 3 skipped, 0 failed**.
- Audit PASS (L2, solo). Post-merge: publish v0.85–v0.91 via `gh workflow run release.yml -f tag=vX.Y.Z`, self-verified by the workflow's PyPI pull-back gate.

## Governance citations (doctrine §6)

- Plan: `docs/plan-qor-phase124-release-pipeline-fix.md`
- Ledger entry #317
- Merkle seal: `b42f2cab6bc14ddb697a651f10efe82119cf620886d3904b2c3b90c4eb6c6318`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
