### PR TITLE
seal: phase 130 - per-feature TDD lint (v0.97.0) (#159)

### DIFF
--- a/.agent/staging/AUDIT_REPORT.md
+++ b/.agent/staging/AUDIT_REPORT.md
@@ -1,22 +1,21 @@
-# AUDIT REPORT — Phase 129 (SG-MergePaceThrottle-A enforcement + wiring, GH #153 + #154)
+# AUDIT REPORT — Phase 130 (Per-feature TDD lint, GH #159)
 
-**Target**: docs/plan-qor-phase129-merge-throttle-enforcement.md
+**Target**: docs/plan-qor-phase130-feature-tdd-lint.md
 **Verdict**: PASS
-**Risk Grade**: L2 (governance enforcement; adds a fail-closed seal gate with a logged override; companion detector wiring is WARN-only)
+**Risk Grade**: L2 (pre-audit governance-lint; WARN-only; plan-text only)
 **Mode**: solo (audit_risk_score: option_b_required=false)
-**Session**: 2026-06-02T1249-0720c2
-**Combination**: #153 + #154 combined per operator request — the two halves of the SG-MergePaceThrottle-A family (backward `merge_velocity_check` + forward `workspace_fragility_check`); #154 restores fields that live in #153's script, so single-cycle contract reconciliation is correct.
+**Session**: 2026-06-02T1326-69c155
 
 ## Passes
 
 - **Prompt Injection**: PASS.
-- **Security L3 / OWASP**: PASS. `--override` is a logged escape (emits `gate_override`); no silent fail-open (A04). The fragility field additions are read-only computed values. No exec/secrets/deserialization.
-- **Section 4 Razor**: PASS. #153 adds an exit-policy branch + logged emission; #154 adds two computed fields + one action branch. Detection logic unchanged.
-- **Self-Application** (originating_remediation=GH #153/#154): PASS — and dogfooded. After ~9 merges today the live merge-velocity grade is likely `exceeded`, so the new fail-closed Step 4.6.8 will attempt to hold THIS phase's seal. That is the enforcer working as designed; the operator seals via the new logged `--override` (a documented high-velocity cluster-sprint authorization). The behavioral tests mock the grade (not live git) to stay deterministic and avoid the known `test_merge_velocity_check` live-git flake.
-- **Test Functionality**: PASS. Mocked-grade tests assert enforce (exit 1) / override (exit 0 + logged event) / healthy (exit 0); fragility tests assert the new fields + the `branch_only` action; wiring tests assert plan + implement name the check. Invoke the unit, assert outputs.
-- **Backward-compat**: the fragility check stays WARN-only at audit Step 0.6 + the new plan/implement sites; only the substantiate merge-velocity gate becomes enforcing (the one #153 names).
-- **Feature Test Coverage / Dependency / Macro / Orphan / Ghost-UI**: PASS / N/A. Stdlib only; both modules exist.
-- **Infrastructure Alignment**: PASS. `merge_velocity_check` wired at substantiate Step 4.6.8 (`|| true`, line 334); `workspace_fragility_check` at audit Step 0.6 (`|| true`, line 164) with NO plan/implement wiring (the #154 gap, grep-confirmed). The plan flips/extends exactly these.
+- **Security L3 / OWASP**: PASS. Pure markdown/regex parse; no subprocess, no eval, no writes.
+- **Section 4 Razor**: PASS. `parse_fit_rows` (pure) + `check_feature_tdd` (policy) + `main`; small, single-purpose.
+- **Self-Application** (originating_remediation=GH #159): PASS. The lint requires a failing-test declaration for NEW/MODIFIED feature rows; this plan's own FIT row is `NEW` with a real `test_path` + behavioral descriptor, so it self-applies clean. Proven by behavior (fixtures), not prose.
+- **Test Functionality**: PASS. Behavioral fixtures: NEW-with-test clears, missing test_path flagged, presence-only descriptor flagged, n/a-justified exempt, src-touch-without-FIT flagged, docs-only clean, CLI exit codes. Invoke the unit, assert findings.
+- **Over-flag containment**: docs-only plans and n/a-justified rows produce zero findings (explicit `test_docs_only_plan_clean` + `test_na_justified_row_exempt`); WARN-only.
+- **Feature Test Coverage / Dependency / Macro / Orphan / Ghost-UI**: PASS / N/A. Stdlib only; new module in qor/scripts.
+- **Infrastructure Alignment**: PASS. `feature_inventory_touches` schema (Phase 73) + `doctrine-feature-tdd.md` exist; the schema doc itself names the deferred V2 lint this ships. Step 0.6 ladder exists for the wiring.
 
 ## Process Pattern Advisory
 
@@ -25,4 +24,4 @@ No repeated-VETO pattern detected.
 
 ## Next action
 
-PASS -> `/qor-implement`. (Seal will require `--override` on the merge-velocity gate; logged.)
+PASS -> /qor-implement.

--- a/.qor/gates/2026-06-02T1326-69c155/audit.json
+++ b/.qor/gates/2026-06-02T1326-69c155/audit.json
@@ -1,0 +1,17 @@
+{
+  "phase": "audit",
+  "session_id": "2026-06-02T1326-69c155",
+  "ts": "2026-06-02T13:28:47Z",
+  "target": "docs/plan-qor-phase130-feature-tdd-lint.md",
+  "verdict": "PASS",
+  "report_path": ".agent/staging/AUDIT_REPORT.md",
+  "risk_grade": "L2",
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.96.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "pass",
+    "ts": "2026-06-02T13:28:47Z"
+  }
+}

--- a/.qor/gates/2026-06-02T1326-69c155/audit_history.jsonl
+++ b/.qor/gates/2026-06-02T1326-69c155/audit_history.jsonl
@@ -1,0 +1,1 @@
+{"ai_provenance":{"host":"unknown","human_oversight":"pass","model_family":"unknown","system":"Qor-logic","ts":"2026-06-02T13:28:47Z","version":"0.96.0"},"phase":"audit","report_path":".agent/staging/AUDIT_REPORT.md","risk_grade":"L2","session_id":"2026-06-02T1326-69c155","target":"docs/plan-qor-phase130-feature-tdd-lint.md","ts":"2026-06-02T13:28:47Z","verdict":"PASS"}

--- a/.qor/gates/2026-06-02T1326-69c155/implement.json
+++ b/.qor/gates/2026-06-02T1326-69c155/implement.json
@@ -1,0 +1,20 @@
+{
+  "phase": "implement",
+  "session_id": "2026-06-02T1326-69c155",
+  "ts": "2026-06-02T13:31:04Z",
+  "files_touched": [
+    "qor/scripts/plan_feature_tdd_lint.py",
+    "tests/test_plan_feature_tdd_lint.py",
+    "qor/skills/governance/qor-audit/SKILL.md",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.96.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "absent",
+    "ts": "2026-06-02T13:31:04Z"
+  }
+}

--- a/.qor/gates/2026-06-02T1326-69c155/plan.json
+++ b/.qor/gates/2026-06-02T1326-69c155/plan.json
@@ -1,0 +1,25 @@
+{
+  "phase": "plan",
+  "session_id": "2026-06-02T1326-69c155",
+  "ts": "2026-06-02T13:28:23Z",
+  "plan_path": "docs/plan-qor-phase130-feature-tdd-lint.md",
+  "phases": [
+    "Phase 1: Lint logic + CLI",
+    "Phase 2: Audit wiring"
+  ],
+  "ci_commands": [
+    "python -m pytest tests/test_plan_feature_tdd_lint.py -q",
+    "python -m qor.cli scripts plan_feature_tdd_lint --plan docs/plan-qor-phase130-feature-tdd-lint.md --repo-root .",
+    "python -m pytest -q"
+  ],
+  "doc_tier": "standard",
+  "originating_remediation": "GH #159",
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.96.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "absent",
+    "ts": "2026-06-02T13:28:23Z"
+  }
+}

--- a/.qor/gates/2026-06-02T1326-69c155/substantiate.json
+++ b/.qor/gates/2026-06-02T1326-69c155/substantiate.json
@@ -1,0 +1,17 @@
+{
+  "phase": "substantiate",
+  "session_id": "2026-06-02T1326-69c155",
+  "ts": "2026-06-02T13:34:48Z",
+  "verdict": "PASS",
+  "merkle_seal": "4ea3ac1acae6eb3f153861efeb9888eed647a7fd19f464aedb76181bc794b6d6",
+  "content_hash": "d420458e5ba57005072c057e74cfa16d23ac27eb1f9590673451bd752aa6657a",
+  "ledger_entry": 323,
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.97.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "pass",
+    "ts": "2026-06-02T13:34:48Z"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ file is the user-facing narrative.
 
 ## [Unreleased]
 
+## [0.97.0] - 2026-06-02
+
+_Built via [Qor-logic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)._
+
+### Added
+- **Phase 130 (#159)**: Per-feature TDD mechanical lint. New `qor.scripts.plan_feature_tdd_lint` parses a plan's `## Feature Inventory Touches` block and flags `NEW`/`MODIFIED` feature rows that lack a failing-test declaration (no real `test_path`, or a presence-only `test_descriptor`), plus a plan that touches `src/` with no FIT block. `n/a-justified` rows + docs-only plans are exempt. Wired WARN-only into `/qor-audit` Step 0.6; the binding VETO stays the Step 3 Feature Test Coverage Pass. Ships #41's deferred V2 enforcement lint.
+
 ## [0.96.0] - 2026-06-02
 
 _Built via [Qor-logic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)._

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
   <a href="https://pypi.org/project/qor-logic/"><img src="https://img.shields.io/pypi/v/qor-logic?color=blue&label=PyPI" alt="PyPI"></a>
   <img src="https://img.shields.io/badge/Python-3.11%2B-blue" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/License-BSL--1.1-orange" alt="License: BSL-1.1">
-  <img src="https://img.shields.io/badge/Tests-2201%20passing-brightgreen" alt="Tests: 2201 passing">
+  <img src="https://img.shields.io/badge/Tests-2211%20passing-brightgreen" alt="Tests: 2211 passing">
   <img src="https://img.shields.io/badge/NIST-SP%20800--218A%20%2B%20AI%20RMF%201.0-004488" alt="NIST SP 800-218A + AI RMF 1.0">
   <img src="https://img.shields.io/badge/OWASP-Top%2010%20%2B%20LLM%20Top%2010-004488" alt="OWASP Top 10 + LLM Top 10">
   <img src="https://img.shields.io/badge/EU%20AI%20Act-aligned-004488" alt="EU AI Act aligned">
   <img src="https://img.shields.io/badge/Skills-30-blue" alt="Skills: 30">
   <img src="https://img.shields.io/badge/Agents-13-blue" alt="Agents: 13">
   <img src="https://img.shields.io/badge/Doctrines-33-blue" alt="Doctrines: 33">
-  <img src="https://img.shields.io/badge/Ledger-322%20entries%20sealed-green" alt="Ledger: 322 entries sealed">
+  <img src="https://img.shields.io/badge/Ledger-323%20entries%20sealed-green" alt="Ledger: 323 entries sealed">
   <img src="https://img.shields.io/badge/Doc%20Tier-system-green" alt="Doc Tier: system">
 </p>
 

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -11704,7 +11704,28 @@ Change class: feature. Tests: 2198 passed / 0 failed / 3 skipped (full suite). A
 **Previous Hash**: `6803569baaf15276311223d32a27515a4fe478eadec68c4d013845ef57d9c4e9`
 **Chain Hash (Merkle seal)**: `be0e3e01c88de71108dd66a25bd7ea082ee433db45d2e45ba7d9c17729df62f8`
 
+### Entry #323: SESSION SEAL -- Phase 130 per-feature TDD lint (v0.97.0)
+
+**Timestamp**: 2026-06-02T13:34:29Z
+**Phase**: SUBSTANTIATE (Phase 130; feature)
+**Author**: Judge
+**Change class**: feature
+**Plan**: docs/plan-qor-phase130-feature-tdd-lint.md
+**Session**: `2026-06-02T1326-69c155`
+**SSDF Practices**: PO.1.4, PS.2.1, PW.1.1
+**Entry ID**: `150ad65e63b0`
+
+**Scope**: Phase 130 implemented (#159): Per-feature TDD mechanical lint. New qor.scripts.plan_feature_tdd_lint parses a plan's ## Feature Inventory Touches block and flags NEW/MODIFIED feature rows lacking a failing-test declaration (no real test_path -> missing-failing-test; presence-only test_descriptor -> presence-only-feature-test) plus a plan touching src/ with no FIT block (undeclared-feature-tdd). n/a-justified rows + docs-only plans exempt. Label-based row parser (separator-agnostic). Wired WARN-only into /qor-audit Step 0.6; binding VETO stays the Step 3 Feature Test Coverage Pass. Ships #41's deferred V2 enforcement lint that the plan.schema.json feature_inventory_touches note flagged as operator-discipline-only. 10 new behavioral tests.
+
+Change class: feature. Tests: 2208 passed / 0 failed / 3 skipped (full suite). Audit PASS (L2 solo).
+
+**Review Boundary**: Operator authorized push + PR post-seal.
+
+**Content Hash**: `d420458e5ba57005072c057e74cfa16d23ac27eb1f9590673451bd752aa6657a`
+**Previous Hash**: `be0e3e01c88de71108dd66a25bd7ea082ee433db45d2e45ba7d9c17729df62f8`
+**Chain Hash (Merkle seal)**: `4ea3ac1acae6eb3f153861efeb9888eed647a7fd19f464aedb76181bc794b6d6`
+
 ---
 
 *Chain integrity: VALID*
-*Session: SEALED* (Phase 129; v0.96.0 local; operator authorized push + PR)
+*Session: SEALED* (Phase 130; v0.97.0 local; operator authorized push + PR)

--- a/docs/plan-qor-phase130-feature-tdd-lint.md
+++ b/docs/plan-qor-phase130-feature-tdd-lint.md
@@ -1,0 +1,100 @@
+# Plan: Per-feature TDD mechanical lint (plan_feature_tdd_lint)
+
+**change_class**: feature
+
+**doc_tier**: standard
+
+**boundaries**:
+- limitations: Ships the V2 mechanical lint `#41` deferred: `qor.scripts.plan_feature_tdd_lint` parses a plan's `## Feature Inventory Touches` block and, for each row whose `operation` is `NEW` or `MODIFIED` (a src-touching feature), requires a failing-test-first declaration — a real `test_path` (not `n/a`/empty) and a behavioral `test_descriptor` (not presence-only). It also flags a plan that touches `src/` in its Affected Files while declaring NO Feature Inventory Touches block. Plan-text lint only (it reads the plan's declared intent, mirroring the doctrine's plan-time contract); it does not inspect git diffs or assert the test was authored chronologically first.
+- non_goals: Verifying the cited test actually fails first / exists on disk (that is the implement-time per-feature TDD + audit Feature Test Coverage Pass); diff/commit-order analysis; flagging `n/a-justified` rows (explicitly exempt); making the lint a hard VETO (it is WARN-only at Step 0.6; the binding VETO remains the audit Feature Test Coverage Pass).
+- exclusions: Docs/governance-only plans (no `src/` Affected Files, empty/absent FIT block) produce zero findings.
+
+## Open Questions
+
+None. The lint operates on the same `feature_inventory_touches` contract the audit Feature Test Coverage Pass consumes; `NEW`/`MODIFIED` operations are the src-touch trigger, `n/a-justified` is exempt (per `doctrine-feature-inventory.md`). Presence-only descriptor detection reuses the established acceptance-question heuristic; WARN-only keeps false positives non-blocking.
+
+## Feature Inventory Touches
+
+(`docs/FEATURE_INDEX.md` absent; declared for traceability. Touches `qor/scripts` + tests.)
+
+- entry_id: `n/a` · operation: `NEW` · test_path: `tests/test_plan_feature_tdd_lint.py` · test_descriptor: `check_feature_tdd flags a NEW/MODIFIED FIT row whose test_path is n/a (missing-failing-test) and a presence-only descriptor, exempts n/a-justified rows, flags a src-touching plan with no FIT block, and returns [] for a docs-only plan`
+
+## Phase 1: Lint logic + CLI (`qor/scripts/plan_feature_tdd_lint.py`)
+
+### Affected Files
+
+- `tests/test_plan_feature_tdd_lint.py` - NEW. Behavioral tests over synthetic plan text (see Unit Tests). Written first; red before the module exists.
+- `qor/scripts/plan_feature_tdd_lint.py` - NEW. FIT-block parser + lint + `main(argv)` dispatchable via `qor-logic scripts plan_feature_tdd_lint`.
+
+### Changes
+
+```python
+KNOWN_FINDING_KINDS = ("missing-failing-test", "presence-only-feature-test", "undeclared-feature-tdd")
+_SRC_AFFECTED_RE = re.compile(r"^[-*]\s+`(src/[^`]+)`", re.MULTILINE)
+_PRESENCE_ONLY_RE = re.compile(r"\b(exists|is defined|appears in|present|defined in|has a row)\b", re.IGNORECASE)
+
+@dataclass(frozen=True)
+class FeatureTddFinding:
+    kind: str
+    entry_id: str
+    detail: str
+
+def parse_fit_rows(plan_text: str) -> list[dict]:
+    """Parse the `## Feature Inventory Touches` block: one dict per bullet with
+    entry_id / operation / test_path / test_descriptor (the `·`-delimited
+    backtick row format)."""
+
+def check_feature_tdd(plan_text: str) -> list[FeatureTddFinding]:
+    """For each NEW/MODIFIED row: missing/`n/a` test_path -> missing-failing-test;
+    presence-only test_descriptor -> presence-only-feature-test. `n/a-justified`
+    rows are exempt. A plan with src/ Affected Files but no FIT block ->
+    undeclared-feature-tdd."""
+
+def main(argv: list[str] | None = None) -> int:
+    """--plan PATH [--repo-root .]. Print findings; exit 1 on any finding else 0
+    (WARN-only at Step 0.6 via `|| true`)."""
+```
+
+De-complecting: `parse_fit_rows` (pure parse) is separate from `check_feature_tdd` (policy) and `main` (process). Trigger is `operation`-based (NEW/MODIFIED), matching the FIT contract.
+
+### Unit Tests
+
+- `tests/test_plan_feature_tdd_lint.py::test_new_row_with_test_clears` - FIT row `operation: NEW`, real `test_path`, behavioral descriptor; `check_feature_tdd` returns `[]`.
+- `::test_new_row_missing_test_path_flagged` - `operation: NEW`, `test_path: n/a`; returns a `missing-failing-test` finding.
+- `::test_presence_only_descriptor_flagged` - `operation: MODIFIED`, real `test_path`, descriptor `route exists`; returns `presence-only-feature-test`.
+- `::test_na_justified_row_exempt` - `operation: n/a-justified`, `test_path: n/a`; returns `[]`.
+- `::test_src_touch_without_fit_block_flagged` - plan with `## Affected Files` listing `src/foo.ts` and NO `## Feature Inventory Touches` heading; returns `undeclared-feature-tdd`.
+- `::test_docs_only_plan_clean` - a plan with no `src/` Affected Files and no FIT block; returns `[]`.
+- `::test_parse_fit_rows_extracts_columns` - a 2-row block; `parse_fit_rows` returns dicts with the four keys populated.
+- `::test_main_exit_1_on_finding` + `::test_main_exit_0_clean` - CLI exit codes over tmp plan files.
+
+## Phase 2: Audit wiring
+
+### Affected Files
+
+- `tests/test_plan_feature_tdd_lint.py` - add `test_audit_invokes_feature_tdd_lint` (prompt-contract).
+- `qor/skills/governance/qor-audit/SKILL.md` - add `qor-logic scripts plan_feature_tdd_lint --plan "$PLAN_PATH" --repo-root . || true` to the Step 0.6 pre-audit lint ladder (WARN-only), with a one-line wiring note.
+- `qor/dist/variants/**` - regenerated.
+
+### Changes
+
+Add the lint to the Step 0.6 ladder under the same `|| true` WARN-only contract as its siblings; the binding VETO stays the Step 3 Feature Test Coverage Pass. Note the lint enforces `doctrine-feature-tdd.md`'s plan-time half mechanically.
+
+### Unit Tests
+
+- `tests/test_plan_feature_tdd_lint.py::test_audit_invokes_feature_tdd_lint` - read `qor-audit/SKILL.md`; assert it names `plan_feature_tdd_lint`.
+
+## Definition of Done
+
+### Deliverable: per-feature TDD lint
+
+- **D1**: a plan that touches src via a NEW/MODIFIED feature row without a failing-test declaration is mechanically flagged at the pre-audit layer; docs-only plans are unaffected.
+- **D2**: `qor/scripts/plan_feature_tdd_lint.py` with `parse_fit_rows`, `check_feature_tdd`, `main`; dispatchable as `qor-logic scripts plan_feature_tdd_lint`.
+- **D3**: audit Step 0.6 wiring; META_LEDGER seal entry; version bump; variants recompiled.
+- **D4**: `tests/test_plan_feature_tdd_lint.py::test_new_row_missing_test_path_flagged` + `::test_na_justified_row_exempt` + `::test_src_touch_without_fit_block_flagged` + `::test_docs_only_plan_clean`.
+
+## CI Commands
+
+- `python -m pytest tests/test_plan_feature_tdd_lint.py -q` — lint + wiring.
+- `python -m qor.cli scripts plan_feature_tdd_lint --plan docs/plan-qor-phase130-feature-tdd-lint.md --repo-root .` — self-applies clean (its FIT row declares a real test).
+- `python -m pytest -q` — full suite green before substantiate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qor-logic"
-version = "0.96.0"
+version = "0.97.0"
 description = "Qor-logic S.H.I.E.L.D. governance skills for Claude Code, Kilo Code, and future AI coding hosts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/qor/dist/manifest.json
+++ b/qor/dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T13:25:05Z",
+  "generated_ts": "2026-06-02T13:34:47Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "f5b9a35022d15b518992ca083f737517a60ef589b3659e04619ae7b1b2487f70"
+      "sha256": "fb24f701e5314c0b2fa8354d28e65e315ab9d76b2449aba00e2beac874534eb7"
     },
     {
       "id": "qor-bootstrap",

--- a/qor/dist/variants/claude/manifest.json
+++ b/qor/dist/variants/claude/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T13:25:05Z",
+  "generated_ts": "2026-06-02T13:34:47Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "f5b9a35022d15b518992ca083f737517a60ef589b3659e04619ae7b1b2487f70"
+      "sha256": "fb24f701e5314c0b2fa8354d28e65e315ab9d76b2449aba00e2beac874534eb7"
     },
     {
       "id": "qor-bootstrap",

--- a/qor/dist/variants/claude/skills/qor-audit/SKILL.md
+++ b/qor/dist/variants/claude/skills/qor-audit/SKILL.md
@@ -165,6 +165,7 @@ qor-logic scripts workspace_fragility_check --repo-root . || true
 qor-logic scripts plan_signature_widening_caller_lint --plan "$PLAN_PATH" --repo-root . || true
 qor-logic scripts plan_data_round_trip_lint --plan "$PLAN_PATH" --repo-root . || true
 qor-logic scripts plan_live_progress_lint --repo-root . || true
+qor-logic scripts plan_feature_tdd_lint --plan "$PLAN_PATH" --repo-root . || true
 ```
 
 `PLAN_PATH` is consumed only as an argv argument; SG-Phase47-A countermeasure honored by construction. Closes the cross-session recurrence pattern flagged across Phase 53/54/55 first audits per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-PreAuditLintGap-A.
@@ -174,6 +175,8 @@ qor-logic scripts plan_live_progress_lint --repo-root . || true
 **Phase 67 wiring (GH #42)**: `plan_text_consistency_lint` (third lint above) catches the COREFORGE-class drift pattern — same operation specified differently at multiple plan sites (commands, dependencies, paths). WARN-only at audit time; the operator amends drift before the binding Infrastructure Alignment Pass in Step 3 would consume an audit cycle. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-PlanTextDrift-A.
 
 **Phase 89 wiring (GH #91)**: `ci_coverage_lint` (fifth lint above) reconciles the plan's `## CI Commands` bullets against the Python-fingerprint `run:` steps discovered in `.github/workflows/*.yml`. Catches the COREFORGE-class credibility failure where a phase seals "all CI green" while a real GitHub Actions job — one the operator simply forgot to enumerate — would fail. WARN-only; tag-only workflows are skipped; environment-setup boilerplate is filtered. The plan may declare a `## CI Coverage Exemptions` block (bullet list with substring patterns) to justify CI jobs that are pre-existing infrastructure not phase-relevant. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-CICoverageDrift-A.
+
+**Phase 130 wiring (GH #159)**: `plan_feature_tdd_lint` (the last lint above) mechanically enforces the plan-time half of `doctrine-feature-tdd.md`: for each `## Feature Inventory Touches` row whose `operation` is `NEW`/`MODIFIED` (a src-touch), it requires a real `test_path` + a behavioral `test_descriptor` (failing-test-first), and flags a plan that touches `src/` with no FIT block. `n/a-justified` rows + docs-only plans are exempt. WARN-only; the binding VETO stays the Step 3 Feature Test Coverage Pass.
 
 **Phase 127 wiring (GH #156)**: `plan_live_progress_lint` (the last lint above) is the mechanical SG-FakeProgress-A detector: it scans the target repo's frontend source for the fake-jump (`0%`->`100%` with no intermediate width write), missing-event-subscription, and error-without-dismiss patterns the Ghost-UI Live-Progress sub-rule describes. WARN-only at this layer; the binding VETO remains the Step 3 Ghost-UI pass (`ghost-ui` category, `live-progress-fake` sub-tag, now a `findings_categories` enum value). Backend-only repos produce zero findings. Escape: `// qor:live-progress-ok`. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-FakeProgress-A.
 

--- a/qor/dist/variants/codex/manifest.json
+++ b/qor/dist/variants/codex/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T13:25:05Z",
+  "generated_ts": "2026-06-02T13:34:47Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "f5b9a35022d15b518992ca083f737517a60ef589b3659e04619ae7b1b2487f70"
+      "sha256": "fb24f701e5314c0b2fa8354d28e65e315ab9d76b2449aba00e2beac874534eb7"
     },
     {
       "id": "qor-bootstrap",

--- a/qor/dist/variants/codex/skills/qor-audit/SKILL.md
+++ b/qor/dist/variants/codex/skills/qor-audit/SKILL.md
@@ -165,6 +165,7 @@ qor-logic scripts workspace_fragility_check --repo-root . || true
 qor-logic scripts plan_signature_widening_caller_lint --plan "$PLAN_PATH" --repo-root . || true
 qor-logic scripts plan_data_round_trip_lint --plan "$PLAN_PATH" --repo-root . || true
 qor-logic scripts plan_live_progress_lint --repo-root . || true
+qor-logic scripts plan_feature_tdd_lint --plan "$PLAN_PATH" --repo-root . || true
 ```
 
 `PLAN_PATH` is consumed only as an argv argument; SG-Phase47-A countermeasure honored by construction. Closes the cross-session recurrence pattern flagged across Phase 53/54/55 first audits per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-PreAuditLintGap-A.
@@ -174,6 +175,8 @@ qor-logic scripts plan_live_progress_lint --repo-root . || true
 **Phase 67 wiring (GH #42)**: `plan_text_consistency_lint` (third lint above) catches the COREFORGE-class drift pattern — same operation specified differently at multiple plan sites (commands, dependencies, paths). WARN-only at audit time; the operator amends drift before the binding Infrastructure Alignment Pass in Step 3 would consume an audit cycle. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-PlanTextDrift-A.
 
 **Phase 89 wiring (GH #91)**: `ci_coverage_lint` (fifth lint above) reconciles the plan's `## CI Commands` bullets against the Python-fingerprint `run:` steps discovered in `.github/workflows/*.yml`. Catches the COREFORGE-class credibility failure where a phase seals "all CI green" while a real GitHub Actions job — one the operator simply forgot to enumerate — would fail. WARN-only; tag-only workflows are skipped; environment-setup boilerplate is filtered. The plan may declare a `## CI Coverage Exemptions` block (bullet list with substring patterns) to justify CI jobs that are pre-existing infrastructure not phase-relevant. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-CICoverageDrift-A.
+
+**Phase 130 wiring (GH #159)**: `plan_feature_tdd_lint` (the last lint above) mechanically enforces the plan-time half of `doctrine-feature-tdd.md`: for each `## Feature Inventory Touches` row whose `operation` is `NEW`/`MODIFIED` (a src-touch), it requires a real `test_path` + a behavioral `test_descriptor` (failing-test-first), and flags a plan that touches `src/` with no FIT block. `n/a-justified` rows + docs-only plans are exempt. WARN-only; the binding VETO stays the Step 3 Feature Test Coverage Pass.
 
 **Phase 127 wiring (GH #156)**: `plan_live_progress_lint` (the last lint above) is the mechanical SG-FakeProgress-A detector: it scans the target repo's frontend source for the fake-jump (`0%`->`100%` with no intermediate width write), missing-event-subscription, and error-without-dismiss patterns the Ghost-UI Live-Progress sub-rule describes. WARN-only at this layer; the binding VETO remains the Step 3 Ghost-UI pass (`ghost-ui` category, `live-progress-fake` sub-tag, now a `findings_categories` enum value). Backend-only repos produce zero findings. Escape: `// qor:live-progress-ok`. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-FakeProgress-A.
 

--- a/qor/dist/variants/gemini/commands/qor-audit.toml
+++ b/qor/dist/variants/gemini/commands/qor-audit.toml
@@ -148,6 +148,7 @@ qor-logic scripts workspace_fragility_check --repo-root . || true
 qor-logic scripts plan_signature_widening_caller_lint --plan "$PLAN_PATH" --repo-root . || true
 qor-logic scripts plan_data_round_trip_lint --plan "$PLAN_PATH" --repo-root . || true
 qor-logic scripts plan_live_progress_lint --repo-root . || true
+qor-logic scripts plan_feature_tdd_lint --plan "$PLAN_PATH" --repo-root . || true
 ```
 
 `PLAN_PATH` is consumed only as an argv argument; SG-Phase47-A countermeasure honored by construction. Closes the cross-session recurrence pattern flagged across Phase 53/54/55 first audits per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-PreAuditLintGap-A.
@@ -157,6 +158,8 @@ qor-logic scripts plan_live_progress_lint --repo-root . || true
 **Phase 67 wiring (GH #42)**: `plan_text_consistency_lint` (third lint above) catches the COREFORGE-class drift pattern — same operation specified differently at multiple plan sites (commands, dependencies, paths). WARN-only at audit time; the operator amends drift before the binding Infrastructure Alignment Pass in Step 3 would consume an audit cycle. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-PlanTextDrift-A.
 
 **Phase 89 wiring (GH #91)**: `ci_coverage_lint` (fifth lint above) reconciles the plan's `## CI Commands` bullets against the Python-fingerprint `run:` steps discovered in `.github/workflows/*.yml`. Catches the COREFORGE-class credibility failure where a phase seals "all CI green" while a real GitHub Actions job — one the operator simply forgot to enumerate — would fail. WARN-only; tag-only workflows are skipped; environment-setup boilerplate is filtered. The plan may declare a `## CI Coverage Exemptions` block (bullet list with substring patterns) to justify CI jobs that are pre-existing infrastructure not phase-relevant. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-CICoverageDrift-A.
+
+**Phase 130 wiring (GH #159)**: `plan_feature_tdd_lint` (the last lint above) mechanically enforces the plan-time half of `doctrine-feature-tdd.md`: for each `## Feature Inventory Touches` row whose `operation` is `NEW`/`MODIFIED` (a src-touch), it requires a real `test_path` + a behavioral `test_descriptor` (failing-test-first), and flags a plan that touches `src/` with no FIT block. `n/a-justified` rows + docs-only plans are exempt. WARN-only; the binding VETO stays the Step 3 Feature Test Coverage Pass.
 
 **Phase 127 wiring (GH #156)**: `plan_live_progress_lint` (the last lint above) is the mechanical SG-FakeProgress-A detector: it scans the target repo's frontend source for the fake-jump (`0%`->`100%` with no intermediate width write), missing-event-subscription, and error-without-dismiss patterns the Ghost-UI Live-Progress sub-rule describes. WARN-only at this layer; the binding VETO remains the Step 3 Ghost-UI pass (`ghost-ui` category, `live-progress-fake` sub-tag, now a `findings_categories` enum value). Backend-only repos produce zero findings. Escape: `// qor:live-progress-ok`. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-FakeProgress-A.
 

--- a/qor/dist/variants/gemini/manifest.json
+++ b/qor/dist/variants/gemini/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T13:25:05Z",
+  "generated_ts": "2026-06-02T13:34:47Z",
   "files": [
     {
       "id": "agent-agent-architect.toml",
@@ -96,7 +96,7 @@
       "id": "qor-audit.toml",
       "source_path": "commands/qor-audit.toml",
       "install_rel_path": "commands/qor-audit.toml",
-      "sha256": "0ea817ec3a86136dad34ce5285963ad5758d23f4971097400d35211ebbfd45f5"
+      "sha256": "af85a5e6fd1db0a620440f7bb90ff5e5a188905acf897afa9b8ad5aa257a48c8"
     },
     {
       "id": "qor-bootstrap.toml",

--- a/qor/dist/variants/kilo-code/manifest.json
+++ b/qor/dist/variants/kilo-code/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T13:25:05Z",
+  "generated_ts": "2026-06-02T13:34:47Z",
   "files": [
     {
       "id": "agent-architect.md",
@@ -120,7 +120,7 @@
       "id": "qor-audit",
       "source_path": "skills/qor-audit/SKILL.md",
       "install_rel_path": "skills/qor-audit/SKILL.md",
-      "sha256": "f5b9a35022d15b518992ca083f737517a60ef589b3659e04619ae7b1b2487f70"
+      "sha256": "fb24f701e5314c0b2fa8354d28e65e315ab9d76b2449aba00e2beac874534eb7"
     },
     {
       "id": "qor-bootstrap",

--- a/qor/dist/variants/kilo-code/skills/qor-audit/SKILL.md
+++ b/qor/dist/variants/kilo-code/skills/qor-audit/SKILL.md
@@ -165,6 +165,7 @@ qor-logic scripts workspace_fragility_check --repo-root . || true
 qor-logic scripts plan_signature_widening_caller_lint --plan "$PLAN_PATH" --repo-root . || true
 qor-logic scripts plan_data_round_trip_lint --plan "$PLAN_PATH" --repo-root . || true
 qor-logic scripts plan_live_progress_lint --repo-root . || true
+qor-logic scripts plan_feature_tdd_lint --plan "$PLAN_PATH" --repo-root . || true
 ```
 
 `PLAN_PATH` is consumed only as an argv argument; SG-Phase47-A countermeasure honored by construction. Closes the cross-session recurrence pattern flagged across Phase 53/54/55 first audits per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-PreAuditLintGap-A.
@@ -174,6 +175,8 @@ qor-logic scripts plan_live_progress_lint --repo-root . || true
 **Phase 67 wiring (GH #42)**: `plan_text_consistency_lint` (third lint above) catches the COREFORGE-class drift pattern — same operation specified differently at multiple plan sites (commands, dependencies, paths). WARN-only at audit time; the operator amends drift before the binding Infrastructure Alignment Pass in Step 3 would consume an audit cycle. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-PlanTextDrift-A.
 
 **Phase 89 wiring (GH #91)**: `ci_coverage_lint` (fifth lint above) reconciles the plan's `## CI Commands` bullets against the Python-fingerprint `run:` steps discovered in `.github/workflows/*.yml`. Catches the COREFORGE-class credibility failure where a phase seals "all CI green" while a real GitHub Actions job — one the operator simply forgot to enumerate — would fail. WARN-only; tag-only workflows are skipped; environment-setup boilerplate is filtered. The plan may declare a `## CI Coverage Exemptions` block (bullet list with substring patterns) to justify CI jobs that are pre-existing infrastructure not phase-relevant. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-CICoverageDrift-A.
+
+**Phase 130 wiring (GH #159)**: `plan_feature_tdd_lint` (the last lint above) mechanically enforces the plan-time half of `doctrine-feature-tdd.md`: for each `## Feature Inventory Touches` row whose `operation` is `NEW`/`MODIFIED` (a src-touch), it requires a real `test_path` + a behavioral `test_descriptor` (failing-test-first), and flags a plan that touches `src/` with no FIT block. `n/a-justified` rows + docs-only plans are exempt. WARN-only; the binding VETO stays the Step 3 Feature Test Coverage Pass.
 
 **Phase 127 wiring (GH #156)**: `plan_live_progress_lint` (the last lint above) is the mechanical SG-FakeProgress-A detector: it scans the target repo's frontend source for the fake-jump (`0%`->`100%` with no intermediate width write), missing-event-subscription, and error-without-dismiss patterns the Ghost-UI Live-Progress sub-rule describes. WARN-only at this layer; the binding VETO remains the Step 3 Ghost-UI pass (`ghost-ui` category, `live-progress-fake` sub-tag, now a `findings_categories` enum value). Backend-only repos produce zero findings. Escape: `// qor:live-progress-ok`. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-FakeProgress-A.
 

--- a/qor/scripts/plan_feature_tdd_lint.py
+++ b/qor/scripts/plan_feature_tdd_lint.py
@@ -1,0 +1,124 @@
+"""Per-feature TDD mechanical lint (Phase 130; GH #159 / #41 V2).
+
+Plan-text lint over a plan's `## Feature Inventory Touches` block. For each row
+whose `operation` is NEW or MODIFIED (a src-touching feature), require a
+failing-test-first declaration: a real `test_path` (not n/a) and a behavioral
+`test_descriptor` (not presence-only). Also flags a plan that touches `src/` in
+its Affected Files while declaring no Feature Inventory Touches block.
+
+WARN-only at `/qor-audit` Step 0.6; the binding VETO remains the Step 3 Feature
+Test Coverage Pass. Enforces the plan-time half of `doctrine-feature-tdd.md`.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+KNOWN_FINDING_KINDS = (
+    "missing-failing-test", "presence-only-feature-test", "undeclared-feature-tdd",
+)
+_FIT_HEADING_RE = re.compile(r"^#+\s*Feature Inventory Touches\s*$", re.IGNORECASE | re.MULTILINE)
+_ANY_HEADING_RE = re.compile(r"^#+\s", re.MULTILINE)
+_SRC_AFFECTED_RE = re.compile(r"^[-*]\s+`(src/[^`]+)`", re.MULTILINE)
+_PRESENCE_ONLY_RE = re.compile(
+    r"\b(exists|is defined|appears in|present|defined|has a row|method defined)\b",
+    re.IGNORECASE,
+)
+_FIELD_RES = {
+    "entry_id": re.compile(r"entry_id:\s*`([^`]+)`"),
+    "operation": re.compile(r"operation:\s*`([^`]+)`"),
+    "test_path": re.compile(r"test_path:\s*`([^`]+)`"),
+    "test_descriptor": re.compile(r"test_descriptor:\s*`(.+?)`\s*$"),
+}
+
+
+@dataclass(frozen=True)
+class FeatureTddFinding:
+    kind: str
+    entry_id: str
+    detail: str
+
+
+def _fit_section(text: str) -> str | None:
+    m = _FIT_HEADING_RE.search(text)
+    if not m:
+        return None
+    rest = text[m.end():]
+    nxt = _ANY_HEADING_RE.search(rest)
+    return rest[:nxt.start()] if nxt else rest
+
+
+def parse_fit_rows(plan_text: str) -> list[dict]:
+    section = _fit_section(plan_text)
+    if section is None:
+        return []
+    rows: list[dict] = []
+    for line in section.splitlines():
+        if "entry_id:" not in line:
+            continue
+        row = {}
+        for key, rx in _FIELD_RES.items():
+            mm = rx.search(line)
+            row[key] = mm.group(1).strip() if mm else ""
+        rows.append(row)
+    return rows
+
+
+def _is_missing(value: str) -> bool:
+    return value == "" or value.lower() in ("n/a", "na", "none", "tbd")
+
+
+def check_feature_tdd(plan_text: str) -> list[FeatureTddFinding]:
+    findings: list[FeatureTddFinding] = []
+    rows = parse_fit_rows(plan_text)
+    has_fit_heading = _FIT_HEADING_RE.search(plan_text) is not None
+
+    for row in rows:
+        op = row.get("operation", "").lower()
+        if op not in ("new", "modified"):
+            continue  # n/a-justified and others are exempt
+        entry = row.get("entry_id", "?")
+        if _is_missing(row.get("test_path", "")):
+            findings.append(FeatureTddFinding(
+                "missing-failing-test", entry,
+                f"{op.upper()} feature row declares no test_path (failing-test-first required)",
+            ))
+            continue
+        desc = row.get("test_descriptor", "")
+        if not desc or _PRESENCE_ONLY_RE.search(desc):
+            findings.append(FeatureTddFinding(
+                "presence-only-feature-test", entry,
+                f"{op.upper()} feature row test_descriptor is presence-only / empty: {desc!r}",
+            ))
+
+    if not has_fit_heading and _SRC_AFFECTED_RE.search(plan_text):
+        findings.append(FeatureTddFinding(
+            "undeclared-feature-tdd", "n/a",
+            "plan touches src/ in Affected Files but declares no Feature Inventory Touches block",
+        ))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="plan_feature_tdd_lint")
+    parser.add_argument("--plan", required=True)
+    parser.add_argument("--repo-root", default=".")
+    args = parser.parse_args(argv)
+
+    path = Path(args.plan)
+    if not path.exists():
+        print(f"plan_feature_tdd_lint: no such file: {path}")
+        return 0
+    findings = check_feature_tdd(path.read_text(encoding="utf-8"))
+    if not findings:
+        return 0
+    for f in findings:
+        print(f"[{f.kind}] {f.entry_id}: {f.detail}")
+    print(f"plan_feature_tdd_lint: {len(findings)} finding(s)")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qor/skills/governance/qor-audit/SKILL.md
+++ b/qor/skills/governance/qor-audit/SKILL.md
@@ -165,6 +165,7 @@ qor-logic scripts workspace_fragility_check --repo-root . || true
 qor-logic scripts plan_signature_widening_caller_lint --plan "$PLAN_PATH" --repo-root . || true
 qor-logic scripts plan_data_round_trip_lint --plan "$PLAN_PATH" --repo-root . || true
 qor-logic scripts plan_live_progress_lint --repo-root . || true
+qor-logic scripts plan_feature_tdd_lint --plan "$PLAN_PATH" --repo-root . || true
 ```
 
 `PLAN_PATH` is consumed only as an argv argument; SG-Phase47-A countermeasure honored by construction. Closes the cross-session recurrence pattern flagged across Phase 53/54/55 first audits per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-PreAuditLintGap-A.
@@ -174,6 +175,8 @@ qor-logic scripts plan_live_progress_lint --repo-root . || true
 **Phase 67 wiring (GH #42)**: `plan_text_consistency_lint` (third lint above) catches the COREFORGE-class drift pattern — same operation specified differently at multiple plan sites (commands, dependencies, paths). WARN-only at audit time; the operator amends drift before the binding Infrastructure Alignment Pass in Step 3 would consume an audit cycle. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-PlanTextDrift-A.
 
 **Phase 89 wiring (GH #91)**: `ci_coverage_lint` (fifth lint above) reconciles the plan's `## CI Commands` bullets against the Python-fingerprint `run:` steps discovered in `.github/workflows/*.yml`. Catches the COREFORGE-class credibility failure where a phase seals "all CI green" while a real GitHub Actions job — one the operator simply forgot to enumerate — would fail. WARN-only; tag-only workflows are skipped; environment-setup boilerplate is filtered. The plan may declare a `## CI Coverage Exemptions` block (bullet list with substring patterns) to justify CI jobs that are pre-existing infrastructure not phase-relevant. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-CICoverageDrift-A.
+
+**Phase 130 wiring (GH #159)**: `plan_feature_tdd_lint` (the last lint above) mechanically enforces the plan-time half of `doctrine-feature-tdd.md`: for each `## Feature Inventory Touches` row whose `operation` is `NEW`/`MODIFIED` (a src-touch), it requires a real `test_path` + a behavioral `test_descriptor` (failing-test-first), and flags a plan that touches `src/` with no FIT block. `n/a-justified` rows + docs-only plans are exempt. WARN-only; the binding VETO stays the Step 3 Feature Test Coverage Pass.
 
 **Phase 127 wiring (GH #156)**: `plan_live_progress_lint` (the last lint above) is the mechanical SG-FakeProgress-A detector: it scans the target repo's frontend source for the fake-jump (`0%`->`100%` with no intermediate width write), missing-event-subscription, and error-without-dismiss patterns the Ghost-UI Live-Progress sub-rule describes. WARN-only at this layer; the binding VETO remains the Step 3 Ghost-UI pass (`ghost-ui` category, `live-progress-fake` sub-tag, now a `findings_categories` enum value). Backend-only repos produce zero findings. Escape: `// qor:live-progress-ok`. Per `qor/references/doctrine-shadow-genome-countermeasures.md` SG-FakeProgress-A.
 

--- a/tests/test_plan_feature_tdd_lint.py
+++ b/tests/test_plan_feature_tdd_lint.py
@@ -1,0 +1,80 @@
+"""Behavioral tests for qor.scripts.plan_feature_tdd_lint (Phase 130; GH #159)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qor.scripts import plan_feature_tdd_lint as ftl
+
+
+def _fit(rows: str) -> str:
+    return "# Plan\n\n## Feature Inventory Touches\n\n" + rows + "\n\n## Phase 1\n"
+
+
+def _row(op: str, test_path: str, desc: str, entry: str = "n/a") -> str:
+    return (f"- entry_id: `{entry}` operation: `{op}` "
+            f"test_path: `{test_path}` test_descriptor: `{desc}`")
+
+
+def test_parse_fit_rows_extracts_columns() -> None:
+    text = _fit(_row("NEW", "tests/test_a.py", "a returns 1") + "\n"
+                + _row("MODIFIED", "tests/test_b.py", "b returns 2"))
+    rows = ftl.parse_fit_rows(text)
+    assert len(rows) == 2
+    assert rows[0]["operation"] == "NEW"
+    assert rows[0]["test_path"] == "tests/test_a.py"
+    assert rows[1]["test_descriptor"] == "b returns 2"
+
+
+def test_new_row_with_test_clears() -> None:
+    text = _fit(_row("NEW", "tests/test_a.py", "POST /x returns 200 + nonce"))
+    assert ftl.check_feature_tdd(text) == []
+
+
+def test_new_row_missing_test_path_flagged() -> None:
+    text = _fit(_row("NEW", "n/a", "the feature works"))
+    kinds = {f.kind for f in ftl.check_feature_tdd(text)}
+    assert "missing-failing-test" in kinds
+
+
+def test_presence_only_descriptor_flagged() -> None:
+    text = _fit(_row("MODIFIED", "tests/test_a.py", "route exists"))
+    kinds = {f.kind for f in ftl.check_feature_tdd(text)}
+    assert "presence-only-feature-test" in kinds
+
+
+def test_na_justified_row_exempt() -> None:
+    text = _fit(_row("n/a-justified", "n/a", "neighbouring feature, untouched"))
+    assert ftl.check_feature_tdd(text) == []
+
+
+def test_src_touch_without_fit_block_flagged() -> None:
+    text = ("# Plan\n\n## Phase 1\n\n### Affected Files\n\n"
+            "- `src/foo.ts` - the handler\n")
+    kinds = {f.kind for f in ftl.check_feature_tdd(text)}
+    assert "undeclared-feature-tdd" in kinds
+
+
+def test_docs_only_plan_clean() -> None:
+    text = ("# Plan\n\n## Phase 1\n\n### Affected Files\n\n"
+            "- `docs/x.md` - a doc\n- `qor/references/y.md` - doctrine\n")
+    assert ftl.check_feature_tdd(text) == []
+
+
+def test_main_exit_1_on_finding(tmp_path: Path) -> None:
+    p = tmp_path / "plan-qor-phase999-x.md"
+    p.write_text(_fit(_row("NEW", "n/a", "the feature works")), encoding="utf-8")
+    assert ftl.main(["--plan", str(p), "--repo-root", str(tmp_path)]) == 1
+
+
+def test_main_exit_0_clean(tmp_path: Path) -> None:
+    p = tmp_path / "plan-qor-phase999-x.md"
+    p.write_text(_fit(_row("NEW", "tests/test_a.py", "a returns the parsed value")),
+                 encoding="utf-8")
+    assert ftl.main(["--plan", str(p), "--repo-root", str(tmp_path)]) == 0
+
+
+def test_audit_invokes_feature_tdd_lint() -> None:
+    text = Path("qor/skills/governance/qor-audit/SKILL.md").read_text(encoding="utf-8")
+    assert "plan_feature_tdd_lint" in text  # prose-lint: ok=prompt-contract


### PR DESCRIPTION
Phase 130 (GH #159). Ships the per-feature TDD mechanical lint #41 deferred to V2.

## What

New `qor.scripts.plan_feature_tdd_lint` parses a plan's `## Feature Inventory Touches` block and flags:
- `NEW`/`MODIFIED` feature rows with no real `test_path` → `missing-failing-test`;
- `NEW`/`MODIFIED` rows with a presence-only `test_descriptor` → `presence-only-feature-test`;
- a plan that touches `src/` in Affected Files with **no** FIT block → `undeclared-feature-tdd`.

`n/a-justified` rows and docs/governance-only plans are exempt. Label-based, separator-agnostic row parser. Wired **WARN-only** into `/qor-audit` Step 0.6; the binding VETO stays the Step 3 Feature Test Coverage Pass. The `plan.schema.json` `feature_inventory_touches` note had explicitly flagged this enforcement as "operator discipline in V1; mechanical lint deferred to V2."

## Verification

- 10 behavioral tests (clears / missing-test / presence-only / n/a-justified-exempt / src-without-FIT / docs-only-clean / parser / CLI / wiring). Full suite: **2208 passed, 3 skipped, 0 failed**. Audit PASS (L2, solo). Self-applies clean on its own plan.

## Governance citations (doctrine §6)

- Plan: `docs/plan-qor-phase130-feature-tdd-lint.md`
- Ledger entry #323
- Merkle seal: `4ea3ac1acae6eb3f153861efeb9888eed647a7fd19f464aedb76181bc794b6d6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
