### PR TITLE
seal: phase 134 - #147 cluster conclusion: graph export (#164) + qor-compliance determination (#151) (v0.101.0)

### DIFF
--- a/.agent/staging/AUDIT_REPORT.md
+++ b/.agent/staging/AUDIT_REPORT.md
@@ -1,20 +1,20 @@
-# AUDIT REPORT — Phase 133 (Pluggable release backends, GH #163)
+# AUDIT REPORT — Phase 134 (Cluster conclusion: graph export #164 + qor-compliance determination #151)
 
-**Target**: docs/plan-qor-phase133-pluggable-release-backends.md
+**Target**: docs/plan-qor-phase134-cluster-conclusion.md
 **Verdict**: PASS
-**Risk Grade**: L2 (release-mechanics; touches the seal version-bump/changelog flow, but the python path delegates to the unchanged bump_version/apply_stamp)
+**Risk Grade**: L2 (additive read-only export capability + decision/determination docs; no behavior change to existing graph/compliance surfaces)
 **Mode**: solo (audit_risk_score: option_b_required=false)
-**Session**: 2026-06-02T1404-c5fda5
+**Session**: 2026-06-02T1431-2ba7f5
 
 ## Passes
 
 - **Prompt Injection**: PASS.
-- **Security L3 / OWASP**: PASS. Backends write only the detected manifest/changelog under repo_root via atomic `os.replace`; no subprocess (beyond the reused git-tag guard), no eval, no secrets. A04 — `NoBackendError` maps to a graceful skip (no fail-open); the shared tag-collision + downgrade guards apply to every archetype, so non-Python repos inherit the same release discipline.
-- **Section 4 Razor**: PASS. Per-backend data (name/filename/pattern/template) + a shared bump policy; small detect/read/stamp functions.
-- **Self-Application / backward-compat** (originating_remediation=GH #163): PASS. The python path delegates to the proven `governance_helpers.bump_version` + `changelog_stamp.apply_stamp`, so THIS repo's own seals are byte-for-byte unchanged (verified by keeping the delegated-path regression tests in the CI set). The new backends serve non-Python downstream repos.
-- **Test Functionality**: PASS. Behavioral fixtures bump real package.json / Cargo.toml files and assert the written version, prepend a section to a non-keepachangelog CHANGELOG, and run an end-to-end non-Python fixture — invoking the units, asserting file content. The bump tests monkeypatch the tag list so they do not couple to this repo's live tags (no live-state flake).
-- **Completeness (no half-measure)**: BOTH the version backend AND the changelog backend land, AND substantiate Step 7.5/7.6 are rewired so non-Python repos actually perform release mechanics (not just ship dormant backend modules) — the AC's intent fully met.
-- **Macro / Dependency / Orphan / Ghost-UI / Infrastructure**: PASS / N/A. Reuses `governance_helpers` internals (`_compute_new`/`_list_tags`/`_highest_tag`) + `changelog_stamp.apply_stamp`; substantiate Step 7.5/7.6 + the `file:pyproject.toml` prerequisite exist as cited.
+- **Security L3 / OWASP**: PASS. Export is read-only (renders the in-memory graph to dict/json/dot); no writes, subprocess, or eval. Docs are prose.
+- **Section 4 Razor**: PASS. `to_dict` is the single source; `to_json`/`to_dot` render from it; small CLI subcommand.
+- **Completeness (no half-measure, operator's standing instruction)**: addressed honestly. #164's AC is decision-centric ("decide which are in-scope + split accepted"); this ships the one cheap/aligned capability (export) AND records a real per-capability decision for the other four (deferred post-1.0 with rationale) — a documented roadmap, not a silent cut. #151 is concluded by the evidenced Option-(c) determination (qor-compliance is FailSafe-owned/absent; grep + prior research brief + Phase 81 confirm) rather than fabricating a redundant skill — which would itself be the anti-pattern. Neither issue is left as a hollow close.
+- **Self-Application**: PASS. The export tests + the doc-contract tests (roadmap covers all five; #151 determination recorded) are behavioral/asserted, not prose claims.
+- **Test Functionality**: PASS. Export tests build a real graph and assert dict/json round-trip + DOT structure + CLI exit/output; doc-contract tests read the artifacts and assert the decisions are present.
+- **Macro / Dependency / Orphan / Ghost-UI / Infrastructure**: PASS / N/A. `ShadowGenomeGraph` + its CLI exist (Phase 139); `qor-governance-compliance` exists, `qor-compliance` confirmed absent; the research brief exists to append the determination to.
 
 ## Process Pattern Advisory
 
@@ -23,4 +23,4 @@ No repeated-VETO pattern detected.
 
 ## Next action
 
-PASS -> /qor-implement.
+PASS -> /qor-implement. (Concludes the #147 cluster.)

--- a/.qor/gates/2026-06-02T1431-2ba7f5/audit.json
+++ b/.qor/gates/2026-06-02T1431-2ba7f5/audit.json
@@ -1,0 +1,17 @@
+{
+  "phase": "audit",
+  "session_id": "2026-06-02T1431-2ba7f5",
+  "ts": "2026-06-02T14:49:53Z",
+  "target": "docs/plan-qor-phase134-cluster-conclusion.md",
+  "verdict": "PASS",
+  "report_path": ".agent/staging/AUDIT_REPORT.md",
+  "risk_grade": "L2",
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.100.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "pass",
+    "ts": "2026-06-02T14:49:53Z"
+  }
+}

--- a/.qor/gates/2026-06-02T1431-2ba7f5/audit_history.jsonl
+++ b/.qor/gates/2026-06-02T1431-2ba7f5/audit_history.jsonl
@@ -1,0 +1,1 @@
+{"ai_provenance":{"host":"unknown","human_oversight":"pass","model_family":"unknown","system":"Qor-logic","ts":"2026-06-02T14:49:53Z","version":"0.100.0"},"phase":"audit","report_path":".agent/staging/AUDIT_REPORT.md","risk_grade":"L2","session_id":"2026-06-02T1431-2ba7f5","target":"docs/plan-qor-phase134-cluster-conclusion.md","ts":"2026-06-02T14:49:53Z","verdict":"PASS"}

--- a/.qor/gates/2026-06-02T1431-2ba7f5/implement.json
+++ b/.qor/gates/2026-06-02T1431-2ba7f5/implement.json
@@ -1,0 +1,21 @@
+{
+  "phase": "implement",
+  "session_id": "2026-06-02T1431-2ba7f5",
+  "ts": "2026-06-02T14:52:11Z",
+  "files_touched": [
+    "qor/scripts/shadow_genome_graph.py",
+    "tests/test_genome_graph_export.py",
+    "docs/shadow-genome-graph-roadmap.md",
+    "docs/research-brief-qor-compliance-provenance-2026-05-29.md",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.100.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "absent",
+    "ts": "2026-06-02T14:52:11Z"
+  }
+}

--- a/.qor/gates/2026-06-02T1431-2ba7f5/plan.json
+++ b/.qor/gates/2026-06-02T1431-2ba7f5/plan.json
@@ -1,0 +1,25 @@
+{
+  "phase": "plan",
+  "session_id": "2026-06-02T1431-2ba7f5",
+  "ts": "2026-06-02T14:49:32Z",
+  "plan_path": "docs/plan-qor-phase134-cluster-conclusion.md",
+  "phases": [
+    "Phase 1: Graph export",
+    "Phase 2: Roadmap decision + qor-compliance determination"
+  ],
+  "ci_commands": [
+    "python -m pytest tests/test_genome_graph_export.py tests/test_shadow_genome_graph.py -q",
+    "python -m qor.cli scripts shadow_genome_graph export --format json",
+    "python -m pytest -q"
+  ],
+  "doc_tier": "standard",
+  "originating_remediation": "GH #164 + #151 (cluster conclusion)",
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.100.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "absent",
+    "ts": "2026-06-02T14:49:32Z"
+  }
+}

--- a/.qor/gates/2026-06-02T1431-2ba7f5/substantiate.json
+++ b/.qor/gates/2026-06-02T1431-2ba7f5/substantiate.json
@@ -1,0 +1,17 @@
+{
+  "phase": "substantiate",
+  "session_id": "2026-06-02T1431-2ba7f5",
+  "ts": "2026-06-02T14:56:36Z",
+  "verdict": "PASS",
+  "merkle_seal": "44c37c2369f1349a330aef47c64cbd786241c99e50c77c79a12a645591dff91e",
+  "content_hash": "dd2ee64627807fd15dd4b8a1b83fe8a1a5fb9a1e24be2154536926c1b42b4d60",
+  "ledger_entry": 327,
+  "ai_provenance": {
+    "system": "Qor-logic",
+    "version": "0.101.0",
+    "host": "unknown",
+    "model_family": "unknown",
+    "human_oversight": "pass",
+    "ts": "2026-06-02T14:56:36Z"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ file is the user-facing narrative.
 
 ## [Unreleased]
 
+## [0.101.0] - 2026-06-02
+
+_Built via [Qor-logic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)._
+
+### Added
+- **Phase 134 (#164, #151)**: #147 cluster conclusion. **#164**: shipped Shadow Genome graph **export** (`ShadowGenomeGraph.to_dict/to_json/to_dot` + `export` CLI subcommand) and recorded a per-capability roadmap decision (`docs/shadow-genome-graph-roadmap.md`) deferring dashboard-API / trust-transition / federation / retention to post-1.0 with rationale. **#151**: recorded the Option-(c) determination that `qor-compliance` is FailSafe-owned/absent from Qor-logic (the in-repo compliance skill is `qor-governance-compliance`, fixed in Phase 81); no duplicate created. Both closed; the half-measure-closures cluster (#147) is fully resolved.
+
 ## [0.100.0] - 2026-06-02
 
 _Built via [Qor-logic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)._

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
   <a href="https://pypi.org/project/qor-logic/"><img src="https://img.shields.io/pypi/v/qor-logic?color=blue&label=PyPI" alt="PyPI"></a>
   <img src="https://img.shields.io/badge/Python-3.11%2B-blue" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/License-BSL--1.1-orange" alt="License: BSL-1.1">
-  <img src="https://img.shields.io/badge/Tests-2238%20passing-brightgreen" alt="Tests: 2238 passing">
+  <img src="https://img.shields.io/badge/Tests-2246%20passing-brightgreen" alt="Tests: 2246 passing">
   <img src="https://img.shields.io/badge/NIST-SP%20800--218A%20%2B%20AI%20RMF%201.0-004488" alt="NIST SP 800-218A + AI RMF 1.0">
   <img src="https://img.shields.io/badge/OWASP-Top%2010%20%2B%20LLM%20Top%2010-004488" alt="OWASP Top 10 + LLM Top 10">
   <img src="https://img.shields.io/badge/EU%20AI%20Act-aligned-004488" alt="EU AI Act aligned">
   <img src="https://img.shields.io/badge/Skills-30-blue" alt="Skills: 30">
   <img src="https://img.shields.io/badge/Agents-13-blue" alt="Agents: 13">
   <img src="https://img.shields.io/badge/Doctrines-33-blue" alt="Doctrines: 33">
-  <img src="https://img.shields.io/badge/Ledger-326%20entries%20sealed-green" alt="Ledger: 326 entries sealed">
+  <img src="https://img.shields.io/badge/Ledger-327%20entries%20sealed-green" alt="Ledger: 327 entries sealed">
   <img src="https://img.shields.io/badge/Doc%20Tier-system-green" alt="Doc Tier: system">
 </p>
 

--- a/docs/GOVERNANCE_INDEX.md
+++ b/docs/GOVERNANCE_INDEX.md
@@ -64,7 +64,7 @@ Informational, slow-drift. Drift signal: factual claims diverge from current cod
 | Process notes | `docs/PROCESS_*.md` |
 | System-tier docs | `docs/architecture.md`, `docs/lifecycle.md`, `docs/operations.md`, `docs/policies.md` |
 | Research briefs | `docs/research-brief-*.md`, `docs/RESEARCH_BRIEF.md` |
-| Roadmaps | `docs/roadmap-*.md` |
+| Roadmaps | `docs/roadmap-*.md`, `docs/*-roadmap.md` |
 | Audits & compliance | `docs/*-audit-*.md`, `docs/security-audit-*.md`, `docs/compliance-*.md` |
 | Reconciliation & drift triage | `docs/reconciliation-*.md`, `docs/phase*.md` |
 | Cluster memos | `docs/cluster-*.md` |

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -11788,7 +11788,28 @@ Change class: feature. Tests: 2235 passed / 0 failed / 3 skipped (full suite). A
 **Previous Hash**: `88f0c824ed475def1da71588c102c6d18e9ec98cae8b36c52e48c7ba29cab418`
 **Chain Hash (Merkle seal)**: `b4494770252a2240f8014a0927c8ffd1face1e4a1ce68625c8bbd8c2606ae9ed`
 
+### Entry #327: SESSION SEAL -- Phase 134 cluster conclusion: graph export + roadmap (#164) + qor-compliance determination (#151) (v0.101.0)
+
+**Timestamp**: 2026-06-02T14:56:16Z
+**Phase**: SUBSTANTIATE (Phase 134; feature)
+**Author**: Judge
+**Change class**: feature
+**Plan**: docs/plan-qor-phase134-cluster-conclusion.md
+**Session**: `2026-06-02T1431-2ba7f5`
+**SSDF Practices**: PO.1.4, PS.2.1, PW.1.1
+**Entry ID**: `324f57206791`
+
+**Scope**: Phase 134 implemented (#164 + #151; #147 cluster CONCLUSION): #164 -- shipped Shadow Genome graph export (ShadowGenomeGraph.to_dict/to_json/to_dot + `export` CLI subcommand, the one cheap+aligned capability of the five) and recorded a per-capability roadmap decision (docs/shadow-genome-graph-roadmap.md): dashboard-API / trust-transition / cross-workspace-federation / retention-pruning DEFERRED post-1.0 with rationale (no new open issues spawned). #151 -- recorded Option (c): qor-compliance is FailSafe-owned and absent from Qor-logic source/dist/manifest (grep + prior research brief + Phase 81 confirm); qor-governance-compliance is the in-repo compliance skill (provenance fixed Phase 81); no duplicate created; F244/FX359 belongs upstream. Both issues closed. Dogfood: the Phase 120 governance-index enforcer correctly fail-closed on the new unregistered roadmap doc until it was registered in GOVERNANCE_INDEX Tier 5. 8 new tests. This phase closes the last two #147 half-measure-closures follow-ons -- the cluster (#147 + #148-#165) is fully resolved.
+
+Change class: feature. Tests: 2243 passed / 0 failed / 3 skipped (full suite). Audit PASS (L2 solo).
+
+**Review Boundary**: Operator authorized push + PR post-seal.
+
+**Content Hash**: `dd2ee64627807fd15dd4b8a1b83fe8a1a5fb9a1e24be2154536926c1b42b4d60`
+**Previous Hash**: `b4494770252a2240f8014a0927c8ffd1face1e4a1ce68625c8bbd8c2606ae9ed`
+**Chain Hash (Merkle seal)**: `44c37c2369f1349a330aef47c64cbd786241c99e50c77c79a12a645591dff91e`
+
 ---
 
 *Chain integrity: VALID*
-*Session: SEALED* (Phase 133; v0.100.0 local; operator authorized push + PR)
+*Session: SEALED* (Phase 134; v0.101.0 local; #147 cluster concluded; operator authorized push + PR)

--- a/docs/plan-qor-phase134-cluster-conclusion.md
+++ b/docs/plan-qor-phase134-cluster-conclusion.md
@@ -1,0 +1,81 @@
+# Plan: Cluster conclusion — Shadow Genome graph export + roadmap decision (#164) + qor-compliance determination (#151)
+
+**change_class**: feature
+
+**doc_tier**: standard
+
+**boundaries**:
+- limitations: Concludes the last two #147 follow-ons. **#164**: of the five declined production-hardening capabilities, **export** is the one cheap + aligned with "Qor-logic proper", so it ships now — `ShadowGenomeGraph.to_dict/to_json/to_dot` + an `export` CLI subcommand; the other four (dashboard/query-API surface, trust-transition modeling, cross-workspace federation, retention/pruning) are evaluated and **deferred post-1.0** with rationale in a roadmap doc (they are SaaS-grade surfaces a governance-skills package does not need to be 1.0-complete). **#151**: records the determination (Option c) that `qor-compliance` is a FailSafe-owned artifact absent from Qor-logic — not retire/fix here; `qor-governance-compliance` is the in-repo compliance skill (already provenance-fixed Phase 81); no duplicate is created.
+- non_goals: Building the four deferred #164 capabilities (documented roadmap, not implemented — they remain post-1.0); creating a `qor-compliance` skill (would duplicate `qor-governance-compliance`, violating #151's no-duplicate guarantee); spawning new open issues (the deferrals are a roadmap doc, not new trackers, so the cluster closes).
+- exclusions: No change to FailSafe's bundled `qor-compliance` (not this repo's artifact).
+
+## Open Questions
+
+None. #164 export is the implementable subset; the heavier four are documented roadmap (operator can re-prioritize post-1.0). #151 resolved Option (c) per operator decision (2026-06-02) + the existing research brief + grep evidence.
+
+## Feature Inventory Touches
+
+(`docs/FEATURE_INDEX.md` absent; declared for traceability. Touches `qor/scripts` + docs + tests.)
+
+- entry_id: `n/a` · operation: `NEW` · test_path: `tests/test_genome_graph_export.py` · test_descriptor: `ShadowGenomeGraph.to_dict/to_json/to_dot export the built nodes+edges (valid JSON round-trips node/edge counts; DOT contains a digraph + each node and edge), and the export CLI subcommand prints the chosen format; the roadmap doc records a decision for all five #164 capabilities + the #151 determination`
+
+## Phase 1: Graph export (#164 accepted capability) — `qor/scripts/shadow_genome_graph.py`
+
+### Affected Files
+
+- `tests/test_genome_graph_export.py` - NEW. Behavioral export tests (see Unit Tests). Written first; red before the methods exist.
+- `qor/scripts/shadow_genome_graph.py` - add `to_dict`, `to_json`, `to_dot` to `ShadowGenomeGraph`; add an `export` subcommand to `main` (`--format json|dot`).
+
+### Changes
+
+```python
+def to_dict(self) -> dict:
+    """{'nodes': [{id,type,label,metadata}...], 'edges': [{id,source,target,type,metadata}...]}"""
+def to_json(self, indent: int = 2) -> str:
+    """json.dumps(self.to_dict(), indent=indent)"""
+def to_dot(self) -> str:
+    """Graphviz: digraph { "<id>" [label="<label>"]; "<src>" -> "<tgt>" [label="<type>"]; }"""
+# main: add subparser `export` with --format {json,dot} (default json); prints to stdout.
+```
+
+De-complecting: `to_dict` is the single source; `to_json`/`to_dot` render from it. Pure (no I/O beyond the existing load).
+
+### Unit Tests
+
+- `tests/test_genome_graph_export.py::test_to_dict_has_nodes_and_edges` - build a graph (2 nodes + 1 edge via the existing add_node/add_edge API); `to_dict()` has `len(nodes)==2`, `len(edges)==1`, with the id/type/label fields.
+- `::test_to_json_roundtrips` - `json.loads(g.to_json())` equals `g.to_dict()` (valid JSON; counts preserved).
+- `::test_to_dot_contains_digraph_and_elements` - `to_dot()` starts a `digraph`, contains each node id and a `->` edge line.
+- `::test_export_cli_json` / `::test_export_cli_dot` - `main(["--path", <jsonl>, "export", "--format", "json"|"dot"])` returns 0 and prints the format (capsys).
+- `::test_export_empty_graph` - export of an empty graph yields `{"nodes": [], "edges": []}` / an empty `digraph` (no crash).
+
+## Phase 2: Roadmap decision (#164) + qor-compliance determination (#151)
+
+### Affected Files
+
+- `tests/test_genome_graph_export.py` - add the roadmap/determination doc-contract tests.
+- `docs/shadow-genome-graph-roadmap.md` - NEW. Records the decision for each of the five #164 capabilities: `export` = SHIPPED (Phase 134); `dashboard/query-API`, `trust-transition modeling`, `cross-workspace federation`, `retention/pruning` = DEFERRED post-1.0, each with a one-paragraph rationale (why a governance-skills package does not need it to be 1.0-complete + what would trigger revisiting). Also records the #151 determination.
+- `docs/research-brief-qor-compliance-provenance-2026-05-29.md` - append a `## Decision (GH #151 closed, 2026-06-02)` section finalizing Option (c): qor-compliance is FailSafe-owned/absent from Qor-logic; `qor-governance-compliance` is the canonical in-repo compliance skill; no duplicate created; F244/FX359 belongs to FailSafe's bundle.
+
+### Changes
+
+The roadmap doc is the durable #164 artifact (decision, not deferral-to-a-new-issue, so the cluster closes). The research-brief decision section finalizes #151. Both are documentary; the seal entry records both closures.
+
+### Unit Tests
+
+- `tests/test_genome_graph_export.py::test_roadmap_covers_all_five_capabilities` - read `shadow-genome-graph-roadmap.md`; assert it names all five (`export`, `dashboard`, `trust`, `federation`, `retention`) and marks `export` shipped.
+- `::test_qor_compliance_determination_recorded` - read the research brief; assert it contains the `## Decision (GH #151 closed` section naming Option (c) / `qor-governance-compliance`.
+
+## Definition of Done
+
+### Deliverable: cluster conclusion
+
+- **D1**: the Shadow Genome graph can be exported (json/dot) via API + CLI; the four heavier capabilities have a documented post-1.0 roadmap decision; the qor-compliance question has a recorded Option-(c) determination.
+- **D2**: `to_dict`/`to_json`/`to_dot` + `export` CLI in `shadow_genome_graph.py`; `docs/shadow-genome-graph-roadmap.md`; the research-brief decision section.
+- **D3**: META_LEDGER seal entry recording both #164 + #151 closures; version bump.
+- **D4**: `tests/test_genome_graph_export.py::test_to_json_roundtrips` + `::test_to_dot_contains_digraph_and_elements` + `::test_roadmap_covers_all_five_capabilities` + `::test_qor_compliance_determination_recorded`.
+
+## CI Commands
+
+- `python -m pytest tests/test_genome_graph_export.py tests/test_shadow_genome_graph.py -q` — export + existing graph tests (no regression).
+- `python -m qor.cli scripts shadow_genome_graph export --format json` — exports the live genome graph (advisory).
+- `python -m pytest -q` — full suite green before substantiate.

--- a/docs/research-brief-qor-compliance-provenance-2026-05-29.md
+++ b/docs/research-brief-qor-compliance-provenance-2026-05-29.md
@@ -56,3 +56,13 @@ The half-measure audit flagged #77 as a "partial-surface closure" (one of two na
 ---
 
 _Research complete. Findings are advisory — the close/redirect decision remains with the operator. Note: the META_LEDGER RESEARCH entry and research gate artifact were intentionally held to avoid interleaving with the staged-but-uncommitted Phase 118 (#150) seal (Entry #311); they can be written once #150 is committed or research is run as its own session._
+
+## Decision (GH #151 closed, 2026-06-02)
+
+**Resolution: Option (c) — not actionable in this repository.** Confirmed at Phase 134 (operator-directed, this session): `qor-compliance` does not exist in Qor-logic source, `qor/dist`, or `qor/dist/manifest.json` (grep re-verified); it is a FailSafe-extension proprietary skill. The canonical compliance skill *in this repo* is `qor-governance-compliance`, whose F244/FX359 provenance was already fixed in Phase 81 (PR #78, v0.55.1). Therefore:
+
+- Neither AC branch (a) retire nor (b) value-add-fix applies — Qor-logic does not own the artifact.
+- No `qor-compliance` skill is created here: doing so would duplicate `qor-governance-compliance`, violating the issue's own "no duplicate coverage" guarantee.
+- The F244/FX359 provenance fix for `qor-compliance` belongs to FailSafe's own skills bundle (upstream).
+
+No duplicate coverage exists between the two compliance skills (only one, `qor-governance-compliance`, is in-repo). GH #151 is closed on this determination.

--- a/docs/shadow-genome-graph-roadmap.md
+++ b/docs/shadow-genome-graph-roadmap.md
@@ -1,0 +1,23 @@
+# Shadow Genome Graph — production-hardening roadmap (GH #164)
+
+Decision record for the five production-hardening capabilities that GH #139 (the
+causal-graph core, PR #146, v0.80.0) declined and #164 tracked. Each is decided
+here so the roadmap is explicit, not buried. Phase 134 closes #164 with this
+record (and ships the one accepted-now capability).
+
+| Capability | Decision | Rationale |
+|---|---|---|
+| **export** (JSON / DOT) | **SHIPPED** (Phase 134) | Cheap, self-contained, and aligned with "Qor-logic proper": operators and CI can serialize the genome for inspection / diffing / external graph tooling. Implemented as `ShadowGenomeGraph.to_dict/to_json/to_dot` + the `export` CLI subcommand. |
+| **dashboard / query-API surface** | **DEFERRED (post-1.0)** | A served query/dashboard API is SaaS-grade product surface, not something a governance-skills *package* needs to be 1.0-complete. The existing `trace` / `query` / `snapshot` CLI already covers programmatic read access. Revisit if a hosted Qor-logic service is built. |
+| **trust-transition modeling** | **DEFERRED (post-1.0)** | Modeling trust state transitions over the genome is research-grade and has no current consumer; the shadow-genome's job today is failure causality, not trust scoring. Revisit if a trust/reputation feature is specified. |
+| **cross-workspace federation** | **DEFERRED (post-1.0)** | The META_LEDGER already carries the federation primitives (content-addressable Entry IDs, `previous_hash` uniqueness checks). A *graph*-level federation layer is heavy and speculative without a multi-workspace deployment driving it. Revisit alongside a concrete federation use case. |
+| **retention / pruning policy** | **DEFERRED (post-1.0)** | The genome is append-only JSONL; growth is real but not yet a measured latency source the way the SKILL.md corpus was (SG-SkillCorpusGrowth-A). Premature pruning risks losing causal history. Revisit when genome size is measured to be a problem; pair with an archival/export step (now available). |
+
+## Status
+
+`export` is the only capability in-scope for the 1.0.0 line; the other four are
+post-1.0 roadmap items. None is split into a new open tracking issue (that would
+keep the #147 cluster open) — this document IS the durable record, and the
+operator can re-prioritize any item into a future phase when a driving use case
+appears. Per `qor/references/doctrine-shadow-genome-countermeasures.md` and the
+GH #139 causal-graph doctrine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qor-logic"
-version = "0.100.0"
+version = "0.101.0"
 description = "Qor-logic S.H.I.E.L.D. governance skills for Claude Code, Kilo Code, and future AI coding hosts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/qor/dist/manifest.json
+++ b/qor/dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T14:30:45Z",
+  "generated_ts": "2026-06-02T14:56:35Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/dist/variants/claude/manifest.json
+++ b/qor/dist/variants/claude/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T14:30:45Z",
+  "generated_ts": "2026-06-02T14:56:35Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/dist/variants/codex/manifest.json
+++ b/qor/dist/variants/codex/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T14:30:45Z",
+  "generated_ts": "2026-06-02T14:56:35Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/dist/variants/gemini/manifest.json
+++ b/qor/dist/variants/gemini/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T14:30:45Z",
+  "generated_ts": "2026-06-02T14:56:35Z",
   "files": [
     {
       "id": "agent-agent-architect.toml",

--- a/qor/dist/variants/kilo-code/manifest.json
+++ b/qor/dist/variants/kilo-code/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "generated_ts": "2026-06-02T14:30:45Z",
+  "generated_ts": "2026-06-02T14:56:35Z",
   "files": [
     {
       "id": "agent-architect.md",

--- a/qor/scripts/shadow_genome_graph.py
+++ b/qor/scripts/shadow_genome_graph.py
@@ -152,6 +152,35 @@ class ShadowGenomeGraph:
             out.append(n)
         return out
 
+    # --- Export (Phase 134; GH #164 accepted capability) ---
+    def to_dict(self) -> dict:
+        """Serialize the full graph: {'nodes': [...], 'edges': [...]}."""
+        return {
+            "nodes": [
+                {"id": n.id, "type": n.type, "label": n.label, "metadata": n.metadata}
+                for n in self.nodes.values()
+            ],
+            "edges": [
+                {"id": e.id, "source": e.source, "target": e.target,
+                 "type": e.type, "metadata": e.metadata}
+                for e in self.edges.values()
+            ],
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+    def to_dot(self) -> str:
+        """Render as a Graphviz digraph."""
+        lines = ["digraph shadow_genome {"]
+        for n in self.nodes.values():
+            label = n.label.replace('"', '\\"')
+            lines.append(f'  "{n.id}" [label="{label}"];')
+        for e in self.edges.values():
+            lines.append(f'  "{e.source}" -> "{e.target}" [label="{e.type}"];')
+        lines.append("}")
+        return "\n".join(lines)
+
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="qor.scripts.shadow_genome_graph")
@@ -163,6 +192,8 @@ def main(argv: list[str] | None = None) -> int:
     sp_trace.add_argument("--max-depth", type=int, default=None)
     sp_query = sub.add_parser("query")
     sp_query.add_argument("--type", default=None)
+    sp_export = sub.add_parser("export")
+    sp_export.add_argument("--format", choices=("json", "dot"), default="json")
     args = parser.parse_args(argv)
     graph = ShadowGenomeGraph(args.path)
     if args.cmd == "snapshot":
@@ -173,6 +204,8 @@ def main(argv: list[str] | None = None) -> int:
     elif args.cmd == "query":
         for n in graph.query(node_type=args.type):
             print(f"{n.id}\t{n.type}\t{n.label}")
+    elif args.cmd == "export":
+        print(graph.to_json() if args.format == "json" else graph.to_dot())
     return 0
 
 

--- a/tests/test_genome_graph_export.py
+++ b/tests/test_genome_graph_export.py
@@ -1,0 +1,73 @@
+"""Behavioral tests for Phase 134 (GH #164 export + #151 determination)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from qor.scripts import shadow_genome_graph as sgg
+
+
+def _graph(tmp_path: Path) -> sgg.ShadowGenomeGraph:
+    g = sgg.ShadowGenomeGraph(tmp_path / "genome.jsonl")
+    a = g.add_node(sgg.GenomeNodeType.CHECKPOINT, "checkpoint-1")
+    b = g.add_node(sgg.GenomeNodeType.FAILURE, "failure-1")
+    g.add_edge(a, b, sgg.GenomeEdgeType.TRIGGERED_BY)
+    return g
+
+
+def test_to_dict_has_nodes_and_edges(tmp_path: Path) -> None:
+    d = _graph(tmp_path).to_dict()
+    assert len(d["nodes"]) == 2
+    assert len(d["edges"]) == 1
+    assert {n["label"] for n in d["nodes"]} == {"checkpoint-1", "failure-1"}
+    assert d["edges"][0]["type"] == "triggered_by"
+
+
+def test_to_json_roundtrips(tmp_path: Path) -> None:
+    g = _graph(tmp_path)
+    assert json.loads(g.to_json()) == g.to_dict()
+
+
+def test_to_dot_contains_digraph_and_elements(tmp_path: Path) -> None:
+    g = _graph(tmp_path)
+    dot = g.to_dot()
+    assert dot.lstrip().startswith("digraph")
+    assert "->" in dot
+    assert "checkpoint-1" in dot and "failure-1" in dot
+
+
+def test_export_empty_graph(tmp_path: Path) -> None:
+    g = sgg.ShadowGenomeGraph(tmp_path / "empty.jsonl")
+    assert g.to_dict() == {"nodes": [], "edges": []}
+    assert "digraph" in g.to_dot()  # valid empty digraph, no crash
+
+
+def test_export_cli_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _graph(tmp_path)
+    rc = sgg.main(["--path", str(tmp_path / "genome.jsonl"), "export", "--format", "json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert json.loads(out)["nodes"]
+
+
+def test_export_cli_dot(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _graph(tmp_path)
+    rc = sgg.main(["--path", str(tmp_path / "genome.jsonl"), "export", "--format", "dot"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "digraph" in out
+
+
+def test_roadmap_covers_all_five_capabilities() -> None:
+    doc = Path("docs/shadow-genome-graph-roadmap.md").read_text(encoding="utf-8").lower()
+    for cap in ("export", "dashboard", "trust", "federation", "retention"):
+        assert cap in doc, f"roadmap missing capability decision: {cap}"
+    assert "shipped" in doc  # export is marked shipped
+
+
+def test_qor_compliance_determination_recorded() -> None:
+    doc = Path("docs/research-brief-qor-compliance-provenance-2026-05-29.md").read_text(encoding="utf-8")
+    assert "## Decision (GH #151 closed" in doc
+    assert "qor-governance-compliance" in doc


### PR DESCRIPTION
Phase 134 (GH #164 + #151). **Concludes the #147 half-measure-closures cluster.** No half-measure: a real deliverable + evidenced determinations.

## #164 — Shadow Genome graph production hardening (decision + accepted capability)

The AC is decision-centric ("decide which of the five are in-scope + split accepted"). Resolution:
- **export — SHIPPED**: `ShadowGenomeGraph.to_dict/to_json/to_dot` + an `export` CLI subcommand (`--format json|dot`). The one cheap, self-contained capability aligned with a governance-skills package.
- **dashboard-API / trust-transition / federation / retention — DEFERRED post-1.0**, each with rationale in `docs/shadow-genome-graph-roadmap.md` (SaaS-grade surfaces a package doesn't need to be 1.0-complete). Documented as a roadmap, not spawned as new open issues — so the cluster actually closes.

## #151 — qor-compliance provenance (determination, Option c)

`qor-compliance` is **a sibling governance repository-owned and absent from Qor-logic** (grep + the prior research brief + Phase 81 confirm). The in-repo compliance skill is `qor-governance-compliance` (provenance already fixed Phase 81). Creating a `qor-compliance` skill would duplicate it (violating the no-duplicate guarantee), so the honest resolution is the recorded Option-(c) determination (appended to the research brief), not a fabricated fix.

## Verification

- 8 new tests (export dict/json/dot + CLI + empty + the two doc-contract tests). Full suite: **2243 passed, 3 skipped, 0 failed**. Audit PASS (L2, solo).
- Dogfood: the Phase 120 governance-index enforcer fail-closed on the new unregistered roadmap doc until it was registered in GOVERNANCE_INDEX Tier 5.

## Governance citations (doctrine §6)

- Plan: `docs/plan-qor-phase134-cluster-conclusion.md`
- Ledger entry #327
- Merkle seal: `44c37c2369f1349a330aef47c64cbd786241c99e50c77c79a12a645591dff91e`

Closes #164 and #151 — the #147 cluster is fully resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
